### PR TITLE
basic API for a check

### DIFF
--- a/agents/monitoring/lua/lib/check/base.lua
+++ b/agents/monitoring/lua/lib/check/base.lua
@@ -1,0 +1,43 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local os = require('os')
+local Object = require('core').Object
+local Emitter = require('core').Emitter
+
+local BaseCheck = Emitter:extend()
+local CheckResult = Object:extend()
+
+function BaseCheck:initialize()
+  self._lastResults = nil
+end
+
+function BaseCheck:run(callback)
+  -- do something, produce a CheckResult
+  local checkResult = CheckResult:new({})
+  self._lastResults = checkResult
+  callback(checkResult)
+end
+
+function CheckResult:initialize(options)
+  self._nextRun = os.time() + 30; -- default to 30 seconds now.
+end
+
+
+local exports = {}
+exports.BaseCheck = BaseCheck
+exports.CheckResult = CheckResult
+return exports

--- a/agents/monitoring/lua/lib/check/init.lua
+++ b/agents/monitoring/lua/lib/check/init.lua
@@ -1,0 +1,23 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local BaseCheck = require('./base').BaseCheck
+local CheckResult = require('./base').CheckResult
+
+local exports = {}
+exports.BaseCheck = BaseCheck
+exports.CheckResult = CheckResult
+return exports

--- a/agents/monitoring/tests/check/init.lua
+++ b/agents/monitoring/tests/check/init.lua
@@ -1,0 +1,33 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local BaseCheck = require('monitoring/lib/check/base').BaseCheck
+local CheckResult = require('monitoring/lib/check/base').CheckResult
+
+exports = {}
+
+exports['test_base_check'] = function(test, asserts)
+  local check = BaseCheck:new()
+  asserts.ok(check._lastResults == nil)
+  check:run(function(results)
+    asserts.ok(results ~= nil)
+    asserts.ok(check._lastResults ~= nil)
+    asserts.ok(check._lastResults._nextRun)
+    test.done()
+  end)
+end
+
+return exports

--- a/agents/monitoring/tests/init.lua
+++ b/agents/monitoring/tests/init.lua
@@ -42,7 +42,7 @@ local function runit(modname, callback)
 end
 
 exports.run = function()
-  async.forEachSeries({"./tls", "./agent-protocol", "./crypto", "./misc"}, runit, function(err)
+  async.forEachSeries({"./tls", "./agent-protocol", "./crypto", "./misc", "./check"}, runit, function(err)
     if err then
       p(err)
       debugm.traceback(err)


### PR DESCRIPTION
I stubbed out what I thought the API around a check should be.   This is needed so I can proceed with the scheduler.
-  doesn't care about serialization yet.
-  all checks have a run() method that accepts a callback with a CheckResult parameter.
