### PR TITLE
Allow user to specify state directory path.

### DIFF
--- a/agents/monitoring/lua/init.lua
+++ b/agents/monitoring/lua/init.lua
@@ -21,7 +21,8 @@ local Entry = {}
 local argv = require("options")
   :usage("Usage: ")
   :describe("e", "entry module")
-  :argv("he:")
+  :describe("s", "state directory path")
+  :argv("he:c:s:")
 
 function Entry.run()
   local mod = argv.args.e or 'monitoring-agent'
@@ -30,7 +31,7 @@ function Entry.run()
   logging.log(logging.INFO, 'Running Module ' .. mod)
 
   local err, msg = pcall(function()
-    require(mod).run()
+    require(mod).run({stateDirectory = argv.args.s})
   end)
 
   if err == false then

--- a/agents/monitoring/lua/monitoring-agent.lua
+++ b/agents/monitoring/lua/monitoring-agent.lua
@@ -27,6 +27,8 @@ local States = require('./lib/states')
 
 local MonitoringAgent = Object:extend()
 
+DEFAULT_STATE_DIRECTORY = '/var/run/agent/states'
+
 function MonitoringAgent:sample()
   local HTTP = require("http")
   local Utils = require("utils")
@@ -130,12 +132,14 @@ function MonitoringAgent:connect(callback)
   self._streams:createConnections(endpoints, callback)
 end
 
-function MonitoringAgent:initialize()
-  self._states = States:new('/var/run/agent/states')
+function MonitoringAgent:initialize(stateDirectory)
+  if not stateDirectory then stateDirectory = DEFAULT_STATE_DIRECTORY end
+  self._states = States:new(stateDirectory)
 end
 
-function MonitoringAgent.run()
-  local agent = MonitoringAgent:new()
+function MonitoringAgent.run(options)
+  if not options then options = {} end
+  local agent = MonitoringAgent:new(options.stateDirectory)
   async.waterfall({
     function(callback)
       agent:loadStates(callback)


### PR DESCRIPTION
This is specifically useful for testing, because we can point it to a directory which doesn't require super-user permissions.
