### PR TITLE
monitoring: #ifndef WIN32 on unistd.h

### DIFF
--- a/agents/monitoring/monitoring.c
+++ b/agents/monitoring/monitoring.c
@@ -21,7 +21,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 static void
 handle_error(const char *msg, virgo_error_t *err)


### PR DESCRIPTION
win32 doesn't have unistd. Guard with _WIN32 like minizip
