### PR TITLE
agents: monitoring: use a fixtures directory

### DIFF
--- a/agents/monitoring/lua/lib/protocol/protocol.lua
+++ b/agents/monitoring/lua/lib/protocol/protocol.lua
@@ -23,7 +23,7 @@ function Response:initialize()
   self.v = 1
   self.id = 1
   self.source = 'endpoint'
-  self.target = 'X'
+  self.target = 'agentA'
   self.result = nil
 end
 

--- a/agents/monitoring/tests/agent-protocol/fixtures.lua
+++ b/agents/monitoring/tests/agent-protocol/fixtures.lua
@@ -1,0 +1,20 @@
+local fs = require('fs')
+local string = require('string')
+
+local fixtures = {}
+
+local strip_newlines = function(str)
+  return str:gsub("\n", " ")
+end
+
+fixture_dir = './agents/monitoring/tests/agent-protocol/fixtures/'
+files = fs.readdirSync(fixture_dir)
+
+for i, v in ipairs(files) do
+  local _, _, name = string.find(v, '(.*).json')
+  local json = fs.readFileSync(fixture_dir .. v)
+  json = strip_newlines(json)
+  fixtures[name] = json
+end
+
+return fixtures

--- a/agents/monitoring/tests/agent-protocol/fixtures/handshake.hello.request.json
+++ b/agents/monitoring/tests/agent-protocol/fixtures/handshake.hello.request.json
@@ -1,0 +1,11 @@
+{
+    "v": "1",
+    "id": 0,
+    "target": "endpoint",
+    "source": "agentA",
+    "method": "handshake.hello",
+    "params": {
+        "token": "MYTOKEN",
+        "agent_id": "MYUID"
+    }
+}

--- a/agents/monitoring/tests/agent-protocol/fixtures/handshake.hello.response.json
+++ b/agents/monitoring/tests/agent-protocol/fixtures/handshake.hello.response.json
@@ -1,0 +1,9 @@
+{
+    "v": "1",
+    "id": 0,
+    "target": "agentA",
+    "source": "endpoint",
+    "result": {
+        "ping_interval": 1000
+    }
+}

--- a/agents/monitoring/tests/agent-protocol/fixtures/ping.request.json
+++ b/agents/monitoring/tests/agent-protocol/fixtures/ping.request.json
@@ -1,0 +1,10 @@
+{
+    "v": "1",
+    "id": 1,
+    "target": "endpoint",
+    "source": "agentA",
+    "method": "heartbeat.ping",
+    "params": {
+        "timestamp": 1325645515246
+    }
+}

--- a/agents/monitoring/tests/agent-protocol/fixtures/ping.response.json
+++ b/agents/monitoring/tests/agent-protocol/fixtures/ping.response.json
@@ -1,0 +1,9 @@
+{
+    "v": "1",
+    "id": 1,
+    "target": "agentA",
+    "source": "endpoint",
+    "result": {
+        "timestamp": 1325645515246
+    }
+}

--- a/agents/monitoring/tests/agent-protocol/handshake.hello.request.json
+++ b/agents/monitoring/tests/agent-protocol/handshake.hello.request.json
@@ -1,1 +1,0 @@
-{ "v": "1", "id": 0, "target": "endpoint", "source": "X", "method": "handshake.hello", "params": { "token": "MYTOKEN", "agent_id": "MYUID" }}

--- a/agents/monitoring/tests/agent-protocol/init.lua
+++ b/agents/monitoring/tests/agent-protocol/init.lua
@@ -22,53 +22,44 @@ local AgentProtocol = require('monitoring/lib/protocol/protocol').AgentProtocol
 local AgentProtocolConnection = require('monitoring/lib/protocol/connection')
 local loggingUtil = require ('monitoring/lib/util/logging')
 
+local fixtures = require('./fixtures')
+
 local exports = {}
 
 exports['test_handshake_hello'] = function(test, asserts)
-  fs.readFile('./agents/monitoring/tests/agent-protocol/handshake.hello.request.json', function(err, data)
-    if (err) then
-      p(err)
-      asserts.is_nil(err)
-      return
-    end
-    local hello = { }
-    hello.data = JSON.parse(data)
-    hello.write = function(_, res)
-      hello.res = res
-    end
-    local agent = AgentProtocol:new(hello.data, hello)
-    agent:request(hello.data)
-    response = JSON.parse(hello.res)
+  local hello = { }
+  local data = fixtures['handshake.hello.request']
+  hello.data = JSON.parse(data)
+  hello.write = function(_, res)
+    hello.res = res
+  end
+  local agent = AgentProtocol:new(hello.data, hello)
+  agent:request(hello.data)
+  response = JSON.parse(hello.res)
 
-    -- TODO: asserts.object_equals in bourbon
-    asserts.equals(response.v, 1)
-    asserts.equals(response.id, 1)
-    asserts.equals(response.source, "endpoint")
-    asserts.equals(response.target, "X")
-    asserts.equals(response.result, nil)
-    test.done()
-  end)
+  -- TODO: asserts.object_equals in bourbon
+  asserts.equals(response.v, 1)
+  asserts.equals(response.id, 1)
+  asserts.equals(response.source, "endpoint")
+  asserts.equals(response.target, "agentA")
+  asserts.equals(response.result, nil)
+  test.done()
 end
 
 exports['test_fragmented_message'] = function(test, asserts)
   local sock = Emitter:new(), conn
-  fs.readFile('./agents/monitoring/tests/agent-protocol/handshake.hello.request.json', function(err, data)
-    if (err) then
-      p(err)
-      asserts.is_nil(err)
-      return
-    end
-    conn = AgentProtocolConnection:new(loggingUtil.makeLogger(), 'MYID', 'TOKEN', sock)
-    conn:on('message', function(msg)
-      asserts.equals(msg.target, 'endpoint')
-      asserts.equals(msg.source, 'X')
-      asserts.equals(msg.id, 0)
-      asserts.equals(msg.params.token, 'MYTOKEN')
-      test.done()
-    end)
-    sock:emit('data', data:sub(1, 4))
-    sock:emit('data', data:sub(4, #data))
+  local data = fixtures['handshake.hello.request']
+  conn = AgentProtocolConnection:new(loggingUtil.makeLogger(), 'MYID', 'TOKEN', sock)
+  conn:on('message', function(msg)
+    asserts.equals(msg.target, 'endpoint')
+    asserts.equals(msg.source, 'agentA')
+    asserts.equals(msg.id, 0)
+    asserts.equals(msg.params.token, 'MYTOKEN')
+    test.done()
   end)
+  sock:emit('data', data:sub(1, 4))
+  sock:emit('data', data:sub(4, #data))
+  sock:emit('data', "\n")
 end
 
 exports['test_multiple_messages_in_a_single_chunk'] = function(test, asserts)


### PR DESCRIPTION
use a fixtures directory for all of the example requests and responses

This makes no functional changes but lays down the framework for testing out all of the commands purely in virgo unit tests.
