### PR TITLE
agents: monitoring: remove = signs in usage

### DIFF
--- a/agents/monitoring/monitoring.c
+++ b/agents/monitoring/monitoring.c
@@ -45,9 +45,9 @@ show_help()
          "\n"
          "Options:\n"
          "  -v, --version         print monitoring-agent's version\n"
-         "  -c, --config=val      Set configuration file path. Default: /etc/rackspace-monitoring-agent.cfg\n"
-         "  -e=val                Entry module.\n"
-         "  -z, --zip=val         Path to Zip Bundle.\n"
+         "  -c, --config val      Set configuration file path. Default: /etc/rackspace-monitoring-agent.cfg\n"
+         "  -e val                Entry module.\n"
+         "  -z, --zip val         Path to Zip Bundle.\n"
          "\n"
          "Documentation can be found at http://monitoring.api.rackspacecloud.com/\n");
   fflush(stdout);


### PR DESCRIPTION
long args don't have equals, don't tell users to use them
