### PR TITLE
lib: virgo-init: implement process.exitCode

### DIFF
--- a/agents/monitoring/tests/init.lua
+++ b/agents/monitoring/tests/init.lua
@@ -58,6 +58,10 @@ local function runit(modname, callback)
 end
 
 exports.run = function()
+  -- set the exitCode to error in case we trigger some
+  -- bug that causes us to exit the loop early
+  process.exitCode = 1
+
   fs.mkdir(tmp_dir, "0755", function()
     async.forEachSeries(TESTS_TO_RUN, runit, function(err)
       if err then
@@ -68,6 +72,7 @@ exports.run = function()
         end)
       end
 
+      process.exitCode = 0
       remove_tmp(function()
         process.exit(failed)
       end)

--- a/lib/lua/virgo-init.lua
+++ b/lib/lua/virgo-init.lua
@@ -405,7 +405,7 @@ function virgo_init.run(name)
   -- Stagents/monitoring/tests/agent-protocol/handshake.hello.response.jsonart the event loop
   native.run()
   -- trigger exit handlers and exit cleanly
-  process.exit(0)
+  process.exit(process.exitCode or 0)
 end
 
 return virgo_init


### PR DESCRIPTION
once and awhile we encounter an error that causes our event loop to exit
before we expect it too. This happened in our scheduler test and
buildbot didn't catch it as an error. So, implement the exitCode logic
that I sent to luvit in virgo:

https://github.com/luvit/luvit/pull/221

I tested this on hash 60ef64fe9d6a2cee78582247e373c507ee7fe3a5 and it
causes make test to exit with a non-zero exit code.
