### PR TITLE
add default SRV queries

### DIFF
--- a/agents/monitoring/lua/lib/util/constants.lua
+++ b/agents/monitoring/lua/lib/util/constants.lua
@@ -13,4 +13,10 @@ exports.DATACENTER_MAX_DELAY_JITTER = 7000
 
 exports.SRV_RECORD_FAILURE_DELAY = 15 * 1000
 exports.SRV_RECORD_FAILURE_DELAY_JITTER = 15 * 1000
+
+exports.DEFAULT_MONITORING_SRV_QUERIES = {
+  '_monitoring_agent._tcp.lon3.stage.monitoring.api.rackspacecloud.com',
+  '_monitoring_agent._tcp.ord1.stage.monitoring.api.rackspacecloud.com'
+}
+
 return exports

--- a/agents/monitoring/lua/monitoring-agent.lua
+++ b/agents/monitoring/lua/monitoring-agent.lua
@@ -30,6 +30,8 @@ local misc = require('./lib/util/misc')
 local States = require('./lib/states')
 local stateFile = require('./lib/state_file')
 
+local table = require('table')
+
 function gc()
   collectgarbage('collect')
 end
@@ -87,6 +89,11 @@ end
 function MonitoringAgent:_loadEndpoints(callback)
   local endpoints
   local query_endpoints
+
+  if not self._config['monitoring_query_endpoints'] then
+    self._config['monitoring_query_endpoints'] = table.concat(constants.DEFAULT_MONITORING_SRV_QUERIES, ',')
+  end
+
   if self._config['monitoring_query_endpoints'] and
      self._config['monitoring_endpoints'] == nil then
     -- Verify that the endpoint addresses are specified in the correct format

--- a/pkg/monitoring/rackspace-monitoring-agent.cfg
+++ b/pkg/monitoring/rackspace-monitoring-agent.cfg
@@ -1,3 +1,2 @@
 monitoring_id REPLACE_ID
 monitoring_token REPLACE_TOKEN
-monitoring_query_endpoints _monitoring_agent._tcp.lon3.stage.monitoring.api.rackspacecloud.com,_monitoring_agent._tcp.ord1.stage.monitoring.api.rackspacecloud.com


### PR DESCRIPTION
- Add default SRV queries into constants.lua. This makes more sense to me than the branding file, since it is specific to monitoring. 
