### PR TITLE
monitoring: refactor request/response naming

### DIFF
--- a/agents/monitoring/lua/lib/client/client.lua
+++ b/agents/monitoring/lua/lib/client/client.lua
@@ -146,7 +146,7 @@ function AgentClient:startPingInterval()
       this._log(logging.DEBUG, fmt('Sending ping (timestamp=%d,sent_ping_count=%d,got_pong_count=%d)',
                                     timestamp, this._sent_ping_count, this._got_pong_count))
       this._sent_ping_count = this._sent_ping_count + 1
-      this.protocol:sendPing(timestamp, function(err, msg)
+      this.protocol:request('heartbeat.ping', timestamp, function(err, msg)
         if err then
           this._log(logging.DEBUG, 'Got an error while sending ping: ' .. tostring(err))
           return

--- a/agents/monitoring/lua/lib/client/connection_messages.lua
+++ b/agents/monitoring/lua/lib/client/connection_messages.lua
@@ -61,7 +61,7 @@ function ConnectionMessages:onMessage(client, msg)
   if msg.method == 'check.schedule_changed' then
     self._lastFetchTime = 0
     client:log(logging.DEBUG, 'received schedule change')
-    client.protocol:sendScheduleChangeAck(msg, function ()
+    client.protocol:respond(msg.method, msg, function ()
       client:log(logging.DEBUG, 'fetching manifest')
       self:fetchManifest(client)
     end)

--- a/agents/monitoring/lua/lib/client/connection_stream.lua
+++ b/agents/monitoring/lua/lib/client/connection_stream.lua
@@ -77,7 +77,7 @@ end
 function ConnectionStream:_sendMetrics(check, checkResults)
   local client = self:getClient()
   if client then
-    client.protocol:sendMetrics(check, checkResults)
+    client.protocol:request('metrics.set', check, checkResults)
   end
 end
 

--- a/agents/monitoring/lua/lib/protocol/connection.lua
+++ b/agents/monitoring/lua/lib/protocol/connection.lua
@@ -36,6 +36,44 @@ STATES.RUNNING = 3
 
 local AgentProtocolConnection = Emitter:extend()
 
+--[[ Request Functions ]]--
+local requests = {}
+
+requests['handshake.hello'] = function(agentId, token, callback)
+  local m = msg.HandshakeHello:new(token, agentId)
+  self:_send(m:serialize(self._msgid), HANDSHAKE_TIMEOUT, 200, callback)
+end
+
+requests['heartbeat.ping'] = function(timestamp, callback)
+  local m = msg.Ping:new(timestamp)
+  self:_send(m:serialize(self._msgid), nil, 200, callback)
+end
+
+requests['manifest.get'] = function(callback)
+  local m = msg.Manifest:new()
+  self:_send(m:serialize(self._msgid), nil, 200, callback)
+end
+
+requests['metrics.set'] = function(check, checkResults, callback)
+  local m = msg.MetricsRequest:new(check, checkResults)
+  self:_send(m:serialize(self._msgid), nil, 200, callback)
+end
+
+--[[ Reponse Functions ]]--
+local responses = {}
+
+responses['check.schedule_changed'] = function(replyTo, callback)
+  local m = msg.ScheduleChangeAck:new(replyTo)
+  self:_send(m:serialize(self._msgid), nil, 200)
+  callback()
+end
+
+responses['system.info'] = function(request, callback)
+  local m = msg.SystemInfoResponse:new(request)
+  self:_send(m:serialize(self._msgid), nil, 200, callback)
+end
+
+
 function AgentProtocolConnection:initialize(log, myid, token, conn)
   assert(conn ~= nil)
   assert(myid ~= nil)
@@ -51,7 +89,17 @@ function AgentProtocolConnection:initialize(log, myid, token, conn)
   self._target = 'endpoint'
   self._timeoutIds = {}
   self._completions = {}
+  self._requests = {}
+  self._responses = {}
   self:setState(STATES.INITIAL)
+end
+
+function AgentProtocolConnection:request(name, ...)
+  return self._requests[name](unpack(arg))
+end
+
+function AgentProtocolConnection:respond(name, ...)
+  return self._responses[name](unpack(arg))
 end
 
 function AgentProtocolConnection:_popLine()
@@ -177,39 +225,6 @@ function AgentProtocolConnection:_setCommandTimeoutHandler(key, timeout, callbac
   self._timeoutIds[key] = timeoutId
 end
 
---[[ Protocol Functions ]]--
-
-function AgentProtocolConnection:sendHandshakeHello(agentId, token, callback)
-  local m = msg.HandshakeHello:new(token, agentId)
-  self:_send(m:serialize(self._msgid), HANDSHAKE_TIMEOUT, 200, callback)
-end
-
-function AgentProtocolConnection:sendPing(timestamp, callback)
-  local m = msg.Ping:new(timestamp)
-  self:_send(m:serialize(self._msgid), nil, 200, callback)
-end
-
-function AgentProtocolConnection:sendSystemInfo(request, callback)
-  local m = msg.SystemInfoResponse:new(request)
-  self:_send(m:serialize(self._msgid), nil, 200, callback)
-end
-
-function AgentProtocolConnection:sendManifest(callback)
-  local m = msg.Manifest:new()
-  self:_send(m:serialize(self._msgid), nil, 200, callback)
-end
-
-function AgentProtocolConnection:sendMetrics(check, checkResults, callback)
-  local m = msg.MetricsRequest:new(check, checkResults)
-  self:_send(m:serialize(self._msgid), nil, 200, callback)
-end
-
-function AgentProtocolConnection:sendScheduleChangeAck(replyTo, callback)
-  local m = msg.ScheduleChangeAck:new(replyTo)
-  self:_send(m:serialize(self._msgid), nil, 200)
-  callback()
-end
-
 --[[ Public Functions ]] --
 
 function AgentProtocolConnection:setState(state)
@@ -218,7 +233,7 @@ end
 
 function AgentProtocolConnection:startHandshake(callback)
   self:setState(STATES.HANDSHAKE)
-  self:sendHandshakeHello(self._myid, self._token, function(err, msg)
+  self:request('handshake.hello', self._myid, self._token, function(err, msg)
     if err then
       self._log(logging.ERR, fmt('handshake failed (message=%s)', err.message))
       callback(err, msg)
@@ -239,7 +254,7 @@ function AgentProtocolConnection:startHandshake(callback)
 end
 
 function AgentProtocolConnection:getManifest(callback)
-  self:sendManifest(function(err, response)
+  self:request('manifest.get', (function(err, response)
     if err then
       callback(err)
     else
@@ -255,7 +270,7 @@ msg - The Incoming Message
 ]]--
 function AgentProtocolConnection:execute(msg)
   if msg.method == 'system.info' then
-    self:sendSystemInfo(msg)
+    self:respond('system.info', msg)
   else
     local err = Error:new(fmt('invalid method [method=%s]', msg.method))
     self:emit('error', err)


### PR DESCRIPTION
the agent API defines method names and the agent is either a requestor
or responder for those names. Avoid hiding the method names behind camel
cases and variations on send/Respond/Ack/etc as it makes discovery
harder.
