### PR TITLE
monitoring: don't generate monitoring_id if given

### DIFF
--- a/agents/monitoring/lua/monitoring-agent.lua
+++ b/agents/monitoring/lua/monitoring-agent.lua
@@ -117,6 +117,11 @@ function MonitoringAgent:_verifyState(callback)
   async.waterfall({
     -- retrieve persistent variables
     function(callback)
+      if self._config['monitoring_id'] ~= nil then
+        callback()
+        return
+      end
+
       self:_getPersistentVariable('monitoring_id', function(err, monitoring_id)
         local getSystemId
         getSystemId = function()


### PR DESCRIPTION
only generate a monitoring_id if one isn't given in the config file.

this enables us to use the aToken/agentA fixture account.
