### PR TITLE
monitoring: filter Local Loopback for UUID generation

### DIFF
--- a/agents/monitoring/lua/monitoring-agent.lua
+++ b/agents/monitoring/lua/monitoring-agent.lua
@@ -69,7 +69,7 @@ function MonitoringAgent:_getSystemId()
   local netifs = s:netifs()
   for i=1, #netifs do
     local eth = netifs[i]:info()
-    if eth.address ~= '127.0.0.1' then
+    if eth['type'] ~= 'Local Loopback' then
       return UUID:new(eth.hwaddr):toString()
     end
   end


### PR DESCRIPTION
I was having a problem of an incomplete UUID. It seems it was caused by having
a lo interface that wasn't 127.0.0.1:

```
{
  broadcast = "0.0.0.0",
  metric = 1,
  mtu = 16436,
  address = "127.0.0.10",
  hwaddr = "00:00:00:00:00:00:00:00",
  flags = 73,
  type = "Local Loopback",
  destination = "127.0.0.10",
  name = "lo:10",
  netmask = "255.255.255.0"
}
```

So, instead of filtering on 127.0.0.1 lets filter on "Local Loopback" in the
type.

Fixes #83
