### PR TITLE
monitoring: use prod query endpoints as default

### DIFF
--- a/agents/monitoring/default/util/constants.lua
+++ b/agents/monitoring/default/util/constants.lua
@@ -14,8 +14,8 @@ exports.SRV_RECORD_FAILURE_DELAY = 15 * 1000
 exports.SRV_RECORD_FAILURE_DELAY_JITTER = 15 * 1000
 
 exports.DEFAULT_MONITORING_SRV_QUERIES = {
-  '_monitoring_agent._tcp.lon3.stage.monitoring.api.rackspacecloud.com',
-  '_monitoring_agent._tcp.ord1.stage.monitoring.api.rackspacecloud.com'
+  '_monitoring_agent._tcp.lon3.prod.monitoring.api.rackspacecloud.com',
+  '_monitoring_agent._tcp.ord1.prod.monitoring.api.rackspacecloud.com'
 }
 
 if os.type() == 'win32' then


### PR DESCRIPTION
Use prod as default now.
