### PR TITLE
monitoring-agent.gyp: add line-emitter to agent

### DIFF
--- a/monitoring-agent.gyp
+++ b/monitoring-agent.gyp
@@ -7,6 +7,7 @@
       'lua_modules/async',
       'lua_modules/bourbon',
       'lua_modules/options',
+      'lua_modules/line-emitter',
       'agents/monitoring/default',
       'agents/monitoring/init.lua',
     ],


### PR DESCRIPTION
custom checks require line-emitter. Ensure it gets built in.
