### PR TITLE
pkg: monitoring: debian: install the upstart script

### DIFF
--- a/pkg/monitoring/debian/rules
+++ b/pkg/monitoring/debian/rules
@@ -2,6 +2,7 @@
 
 DESTDIR=$(CURDIR)/debian/rackspace-monitoring-agent
 ETCDIR=$(DESTDIR)/etc
+INITDIR=$(DESTDIR)/etc/init
 BINDIR=$(DESTDIR)/usr/bin
 SHAREDIR=$(DESTDIR)/usr/share/rackspace-monitoring-agent
 
@@ -23,6 +24,8 @@ install: build
 	dh_prep
 	dh_installdirs
 	DESTDIR=$(DESTDIR) $(MAKE) install
+	install -d $(INITDIR)
+	install -o root -g root -m 644 pkg/monitoring/upstart/rackspace-monitoring-agent.conf $(INITDIR)
 
 binary-arch: build install
 	dh_testdir


### PR DESCRIPTION
install the upstart script to /etc/init/rackspace-monitoring-agent.conf
