### PR TITLE
Only retrieve manifest if agent is bound.

### DIFF
--- a/agents/monitoring/default/client/client.lua
+++ b/agents/monitoring/default/client/client.lua
@@ -120,7 +120,9 @@ function AgentClient:connect()
         self:emit('error', err)
       else
         self._heartbeat_interval = msg.result.heartbeat_interval
-        self:emit('handshake_success')
+        self._entity_id = msg.result.entity_id
+
+        self:emit('handshake_success', msg.result)
       end
     end)
   end)

--- a/agents/monitoring/default/client/connection_messages.lua
+++ b/agents/monitoring/default/client/connection_messages.lua
@@ -29,8 +29,11 @@ function ConnectionMessages:onClientEnd(client)
   client:log(logging.INFO, 'Detected client disconnect')
 end
 
-function ConnectionMessages:onHandshake(client)
-  self:fetchManifest(client);
+function ConnectionMessages:onHandshake(client, data)
+  -- Only retrieve manifest if agent is bound to an entity
+  if data.entity_id then
+    self:fetchManifest(client)
+  end
 end
 
 function ConnectionMessages:fetchManifest(client)


### PR DESCRIPTION
Changes the agent to only retrieve a manifest upon successful handshake if agent is bound to an entity.
