### PR TITLE
line-emitter: upgrade and use and new API

### DIFF
--- a/agents/monitoring/default/check/plugin.lua
+++ b/agents/monitoring/default/check/plugin.lua
@@ -107,12 +107,12 @@ function PluginCheck:run(callback)
     callback(checkResult)
   end)
 
-  lineEmitter:on('line', function(line)
+  lineEmitter:on('data', function(line)
     self:_handleLine(checkResult, line)
   end)
 
   child.stdout:on('data', function(chunk)
-    lineEmitter:feed(chunk)
+    lineEmitter:write(chunk)
   end)
 
   child.stderr:on('data', function(chunk)

--- a/agents/monitoring/tests/collector/init.lua
+++ b/agents/monitoring/tests/collector/init.lua
@@ -90,7 +90,7 @@ exports['test_traceroute'] = function(test, asserts)
       local le = LineEmitter:new()
       local emittedLines = 0
 
-      le:on('line', function(line)
+      le:on('data', function(line)
         local parsed
         emittedLines = emittedLines + 1
 
@@ -111,7 +111,7 @@ exports['test_traceroute'] = function(test, asserts)
       function (res)
         res:on('data', function (chunk)
           chunk = chunk and chunk or ''
-          le:feed(chunk)
+          le:write(chunk)
         end)
         res:on('end', function()
           asserts.equals(emittedLines, 1)

--- a/lua_modules/line-emitter/lib/emitter.lua
+++ b/lua_modules/line-emitter/lib/emitter.lua
@@ -1,21 +1,21 @@
-local Emitter = require('core').Emitter
+local iStream = require('core').iStream
 
 local exports = {}
 
-local LineEmitter = Emitter:extend()
+local LineEmitter = iStream:extend()
 
 function LineEmitter:initialize(initialBuffer)
   self._buffer = initialBuffer and initialBuffer or ''
 end
 
-function LineEmitter:feed(chunk)
+function LineEmitter:write(chunk)
   local line
 
   self._buffer = self._buffer .. chunk
 
   line = self:_popLine()
   while line do
-    self:emit('line', line)
+    self:emit('data', line)
     line = self:_popLine()
   end
 end

--- a/lua_modules/line-emitter/tests/test-line-emitter.lua
+++ b/lua_modules/line-emitter/tests/test-line-emitter.lua
@@ -7,7 +7,7 @@ exports['test_line_emitter_single_chunk'] = function(test, asserts)
   local lines = {'test1', 'test2', 'test3', 'test4'}
   local le = LineEmitter:new()
 
-  le:on('line', function(line)
+  le:on('data', function(line)
     count = count + 1
     asserts.equals(line, lines[count])
 
@@ -16,7 +16,7 @@ exports['test_line_emitter_single_chunk'] = function(test, asserts)
     end
   end)
 
-  le:feed('test1\ntest2\ntest3\ntest4\n')
+  le:write('test1\ntest2\ntest3\ntest4\n')
 end
 
 exports['test_line_emitter_multiple_chunks'] = function(test, asserts)
@@ -24,7 +24,7 @@ exports['test_line_emitter_multiple_chunks'] = function(test, asserts)
   local lines = {'test1', 'test2', 'test3', 'test4', 'test5'}
   local le = LineEmitter:new()
 
-  le:on('line', function(line)
+  le:on('data', function(line)
     count = count + 1
     asserts.equals(line, lines[count])
 
@@ -33,11 +33,11 @@ exports['test_line_emitter_multiple_chunks'] = function(test, asserts)
     end
   end)
 
-  le:feed('test1\n')
-  le:feed('test2\n')
-  le:feed('test3\n')
-  le:feed('test4\ntest5')
-  le:feed('\n')
+  le:write('test1\n')
+  le:write('test2\n')
+  le:write('test3\n')
+  le:write('test4\ntest5')
+  le:write('\n')
 end
 
 return exports

--- a/lua_modules/traceroute/lib/traceroute.lua
+++ b/lua_modules/traceroute/lib/traceroute.lua
@@ -70,7 +70,7 @@ function Traceroute:_run(target)
   local emitter = Emitter:new()
   local stderrBuffer = ''
 
-  lineEmitter:on('line', function(line)
+  lineEmitter:on('data', function(line)
     local hops = self:_parseLine(line)
     local hop
 
@@ -85,7 +85,7 @@ function Traceroute:_run(target)
   end)
 
   child.stdout:on('data', function(chunk)
-    lineEmitter:feed(chunk)
+    lineEmitter:write(chunk)
   end)
 
   child.stderr:on('data', function(chunk)


### PR DESCRIPTION
The new API in a nutshell:

s/feed/write/g
s/on('line'')/on('data')/g

See https://github.com/racker/luvit-line-emitter/commit/4554eaece6d559f43917a8ce517f29cf05c3125d
