### PR TITLE
monitoring: add crash entry point to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ test: tests
 tests: all
 	python tools/build.py test
 
+crash: all
+	python tools/build.py crash
+
 test_endpoint:
 	python tools/build.py test_endpoint
 
@@ -128,4 +131,4 @@ update:
 	git submodule foreach git fetch && git submodule update --init --recursive
 
 
-.PHONY: clean dist distclean all test tests endpoint-tests rpm $(spec_file_built) deb pkg
+.PHONY: clean dist distclean all test tests crash endpoint-tests rpm $(spec_file_built) deb pkg

--- a/agents/monitoring/crash/init.lua
+++ b/agents/monitoring/crash/init.lua
@@ -1,0 +1,17 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+virgo.force_crash()

--- a/monitoring-agent.gyp
+++ b/monitoring-agent.gyp
@@ -33,6 +33,7 @@
     'test_modules': [
       '<@(modules_agent)',
       '<@(modules_collector)',
+      'agents/monitoring/crash',
       'agents/monitoring/tests',
       'agents/monitoring/tests/tls',
       'agents/monitoring/tests/crypto',

--- a/tools/build.py
+++ b/tools/build.py
@@ -43,13 +43,13 @@ def test_cmd(additional=""):
 
   return '%s -c %s -s %s %s' % (agent, monitoring_config, state_config, additional)
 
-def test(stdout=None):
+def test(stdout=None, entry="tests"):
   if sys.platform != "win32":
     agent_tests = os.path.join(root, 'out', 'Debug', 'monitoring-test.zip')
   else:
     agent_tests = os.path.join(root, 'Debug', 'monitoring-test.zip')
 
-  cmd = test_cmd("--zip %s -e tests" % agent_tests)
+  cmd = test_cmd("--zip %s -e %s" % (agent_tests, entry))
   print cmd
   rc = 0
   if stdout == None:
@@ -63,12 +63,16 @@ def test_std():
 
 def test_pipe():
   test(subprocess.PIPE)
-  
+
 def test_file():
   stdout = open("stdout", "w+")
   test(stdout)
 
+def crash():
+  test(None, "crash")
+
 commands = {
+  'crash': crash,
   'build': build,
   'pkg': pkg,
   'test': test_std,

--- a/tools/lua2zip.py
+++ b/tools/lua2zip.py
@@ -18,6 +18,7 @@ luvit_keystone_client_lua = os.path.join('modules', 'luvit-keystone-client')
 luvit_lua = os.path.join('deps', 'luvit', 'lib', 'luvit')
 monitoring_lua = os.path.join('agents', 'monitoring', 'default')
 collector_lua = os.path.join('agents', 'monitoring', 'collector')
+crash_lua = os.path.join('agents', 'monitoring', 'crash')
 monitoring_tests = os.path.join('agents', 'monitoring', 'tests')
 
 modules = {
@@ -45,6 +46,8 @@ modules = {
     generate_bundle_map('modules/monitoring/collector', 'agents/monitoring/collector'),
   monitoring_tests:
     generate_bundle_map('modules/monitoring/tests', 'agents/monitoring/tests'),
+  crash_lua:
+    generate_bundle_map('modules/monitoring/crash', 'agents/monitoring/crash'),
 }
 
 target = sys.argv[1]


### PR DESCRIPTION
add an entry point that just crashes so we can test breakpad.

Usage:

```
./out/Debug/monitoring-agent -c --zip monitoring-test.zip -e crash
```
