### PR TITLE
monitoring: check: API add timestamp to check_metrics.post

### DIFF
--- a/agents/monitoring/default/check/base.lua
+++ b/agents/monitoring/default/check/base.lua
@@ -96,11 +96,17 @@ function CheckResult:initialize(check, options)
   self._metrics = {}
   self._state = 'available'
   self._status = nil
+  self:setTimestamp(self._options.timestamp)
   self._nextRun = os.time() + check.period
   self._timestamp = vtime.now()
 end
 
 function CheckResult:getTimestamp()
+  return self._timestamp
+end
+
+function CheckResult:setTimestamp(timestamp)
+  self._timestamp = timestamp or vtime.now()
   return self._timestamp
 end
 


### PR DESCRIPTION
1. API Change: add a timestamp to the params of check_metrics.post
2. CheckResult takes a timestamp option for checks that want to have a
   custom timestmap
3. Write two tests, one that tests the serialization and one that tests
   the CheckResults directly.
