### PR TITLE
monitoring: protocol: test ignored response and hello timeout

### DIFF
--- a/agents/monitoring/default/errors.lua
+++ b/agents/monitoring/default/errors.lua
@@ -29,9 +29,17 @@ function AuthTimeoutError:initialize(message)
   self.message = message
 end
 
+--[[ ResponseTimeoutError --]]
+local ResponseTimeoutError = Error:extend()
+function ResponseTimeoutError:initialize(message)
+  Error.initialize(self)
+  self.message = message
+end
+
 --[[ Exports ]]--
 
 local exports = {}
 exports.UserResponseError = UserResponseError
 exports.AuthTimeoutError = AuthTimeoutError
+exports.ResponseTimeoutError = ResponseTimeoutError
 return exports

--- a/agents/monitoring/tests/fixtures/protocol/init.lua
+++ b/agents/monitoring/tests/fixtures/protocol/init.lua
@@ -1,6 +1,7 @@
 local path = require('path')
 local fs = require('fs')
 local string = require('string')
+local JSON = require('json')
 
 local fixtures = nil
 
@@ -28,5 +29,10 @@ local base = path.join('agents', 'monitoring', 'tests', 'fixtures', 'protocol')
 
 fixtures = load_fixtures(base)
 fixtures['invalid-version'] = load_fixtures(path.join(base, 'invalid-version'))
+
+fixtures.prepareJson = function(msg)
+  local data = JSON.stringify(msg)
+  return strip_newlines(data)
+end
 
 return fixtures


### PR DESCRIPTION
add logging in case of a response from the server with no matching
completion key

test this by having a hello response sent with a mismatched completion
key
