### PR TITLE
Add configure --ninja to enable basic ninja usage.

### DIFF
--- a/configure
+++ b/configure
@@ -25,6 +25,11 @@ parser.add_option("--prefix",
     dest="prefix",
     help="Select the install prefix (defaults to /usr/local)")
 
+parser.add_option("--ninja",
+    action="store_true",
+    dest="ninja_build",
+    help="Generate files for the ninja build system")
+
 (options, args) = parser.parse_args()
 
 
@@ -142,7 +147,10 @@ if sys.platform == "win32":
         'deps/luvit/deps/openssl/openssl-configs/realized/openssl')
     rv = os.system("python tools\gyp_virgo -f msvs -G msvs_version=2010")
 else:
-    rv = os.system("tools/gyp_virgo")
+    cmd = "tools/gyp_virgo"
+    if options.ninja_build:
+        cmd += " -f ninja"
+    rv = os.system(cmd)
 
 if rv != 0:
     sys.exit(rv)

--- a/tools/gyp_virgo
+++ b/tools/gyp_virgo
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     args.extend(['-f', 'xcode'])
 
   # There's a bug with windows which doesn't allow this feature.
-  if sys.platform != 'win32':
+  if sys.platform != 'win32'  and 'ninja' not in args:
 
     # Tell gyp to write the Makefiles into output_dir
     args.extend(['--generator-output', output_dir])


### PR DESCRIPTION
Mirrors what node is doing for now.

Ideally need to revamp our Makefile to detect the buildsystem being used.

Build with no changes takes `350ms` with Ninja. Fuck yeah.
