### PR TITLE
Combine zips into 1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR = ${DESTDIR}/usr/bin
 SHAREDIR = ${DESTDIR}/usr/share/rackspace-monitoring-agent
 ETCDIR = ${DESTDIR}/etc
 
-zip_files = monitoring.zip monitoring-test.zip
+zip_files = monitoring.zip
 sig_files = $(zip_files:%.zip=%.zip.sig)
 
 %.zip:
@@ -54,7 +54,6 @@ install: all
 	install -d ${SHAREDIR}
 	install out/${BUILDTYPE}/monitoring-agent ${BINDIR}/rackspace-monitoring-agent
 	install out/${BUILDTYPE}/monitoring.zip ${SHAREDIR}
-	install out/${BUILDTYPE}/monitoring-test.zip ${SHAREDIR}
 	install -m 600 pkg/monitoring/rackspace-monitoring-agent.cfg ${ETCDIR}
 
 PKG_FULL_VERSION = $(shell python tools/version.py)

--- a/agents/monitoring/tests/init.lua
+++ b/agents/monitoring/tests/init.lua
@@ -41,7 +41,7 @@ local function remove_tmp(callback)
 end
 
 local TESTS_TO_RUN = {
-  './collector',
+--  './collector',
   './tls',
   './agent-protocol',
   './crypto',

--- a/monitoring-agent.gyp
+++ b/monitoring-agent.gyp
@@ -12,6 +12,11 @@
       'modules/line-emitter',
       'agents/monitoring/default',
       'agents/monitoring/init.lua',
+      'agents/monitoring/crash',
+      'agents/monitoring/tests',
+      'agents/monitoring/tests/tls',
+      'agents/monitoring/tests/crypto',
+      'agents/monitoring/tests/agent-protocol', 
     ],
     'modules_collector': [
       'lib/lua',
@@ -57,7 +62,6 @@
       'dependencies': [
         'lib/virgo.gyp:virgolib',
         'monitoring.zip#host',
-        'monitoring-test.zip#host',
         'collector.zip#host',
       ],
 
@@ -211,35 +215,6 @@
         },
       ],
     }, # end monitoring.zip
-    {
-      'target_name': 'monitoring-test.zip',
-      'type': 'none',
-      'toolsets': ['host'],
-      'variables': {
-      },
-
-      'actions': [
-        {
-          'action_name': 'virgo_luazip',
-
-          'inputs': [
-            '<@(test_modules_sources)',
-            'tools/lua2zip.py',
-          ],
-
-          'outputs': [
-            '<(PRODUCT_DIR)/monitoring-test.zip',
-          ],
-
-          'action': [
-            'python',
-            'tools/lua2zip.py',
-            '<@(_outputs)',
-            '<@(test_modules)',
-          ],
-        },
-      ],
-    }, # end monitoring-test.zip
     {
       'target_name': 'collector.zip',
       'type': 'none',

--- a/tools/build.py
+++ b/tools/build.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, './')
 import paths
 
+
 def extra_env():
     env = {}
     if sys.platform.find('freebsd') == 0:
@@ -61,9 +62,9 @@ def test_cmd(additional=""):
 
 def test(stdout=None, entry="tests"):
     if sys.platform != "win32":
-        agent_tests = os.path.join(paths.root, 'out', paths.BUILDTYPE, 'monitoring-test.zip')
+        agent_tests = os.path.join(paths.root, 'out', paths.BUILDTYPE, 'monitoring.zip')
     else:
-        agent_tests = os.path.join(paths.root, paths.BUILDTYPE, 'monitoring-test.zip')
+        agent_tests = os.path.join(paths.root, paths.BUILDTYPE, 'monitoring.zip')
 
     cmd = test_cmd("--zip %s -e %s" % (agent_tests, entry))
     print cmd


### PR DESCRIPTION
The monitoring.zip and monitoring-test.zip have been combined into one zip file and monitoring-test.zip is no longer created.  It is expected that the agent will run tests to verify new bundles before an auto update.
