### PR TITLE
tools: build: move path logic into paths module

### DIFF
--- a/agents/monitoring/runner
+++ b/agents/monitoring/runner
@@ -6,22 +6,20 @@ import sys
 import signal
 
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-build_dir = os.path.join(root, 'out')
-
-agent = os.environ['AGENT_BIN']
-luvit = os.environ['LUVIT_BIN']
+sys.path.insert(0, os.path.join(root, 'tools'))
+import paths
 
 def test_cmd(additional=""):
-  state_config = os.path.join(root, 'contrib')
-  monitoring_config = os.path.join(root, 'agents', 'monitoring', 'tests', 'fixtures', 'monitoring-agent-localhost.cfg')
+  state_config = os.path.join(paths.root, 'contrib')
+  monitoring_config = os.path.join(paths.root, 'agents', 'monitoring', 'tests', 'fixtures', 'monitoring-agent-localhost.cfg')
   zip_file = "monitoring.zip"
 
-  return '%s -z %s -c %s -s %s %s' % (agent, zip_file, monitoring_config, state_config, additional)
+  return '%s -z %s -c %s -s %s %s' % (paths.agent, zip_file, monitoring_config, state_config, additional)
 
 def test_server_fixture(stdout=None):
   server = os.path.join('agents', 'monitoring', 'tests', 'fixtures', 'protocol', 'server.lua')
 
-  cmd = "%s %s" % (luvit, server)
+  cmd = "%s %s" % (paths.luvit, server)
   print cmd
   rc = 0
   if stdout == None:
@@ -32,7 +30,7 @@ def test_server_fixture(stdout=None):
 
 def test_server_fixture_blocking(stdout=None):
   server = os.path.join('agents', 'monitoring', 'tests', 'fixtures', 'protocol', 'server.lua')
-  proc = subprocess.Popen([luvit, server])
+  proc = subprocess.Popen([paths.luvit, server])
 
   def handler(signum, frame):
     print(proc)

--- a/tools/build.py
+++ b/tools/build.py
@@ -4,28 +4,8 @@ import os
 import subprocess
 import sys
 
-# TODO: release/debug
-BUILDTYPE = 'Debug'
-
-if os.environ.get('BUILDTYPE'):
-    BUILDTYPE = os.environ.get('BUILDTYPE')
-
-root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-build_dir = os.path.join(root, 'out')
-
-if sys.platform != "win32":
-    agent = os.path.join(root, 'out', BUILDTYPE, 'monitoring-agent')
-else:
-    agent = os.path.join(root, BUILDTYPE, 'monitoring-agent.exe')
-
-if sys.platform != "win32":
-    luvit = os.path.join(root, 'out', BUILDTYPE, 'luvit')
-else:
-    luvit = os.path.join(root, BUILDTYPE, 'luvit.exe')
-
-os.environ['AGENT_BIN'] = agent
-os.environ['LUVIT_BIN'] = luvit
-
+sys.path.insert(0, './')
+import paths
 
 def extra_env():
     env = {}
@@ -37,9 +17,9 @@ def extra_env():
 
 def build():
     if sys.platform.find('freebsd') == 0:
-        cmd = 'gmake -C %s' % build_dir
+        cmd = 'gmake -C %s' % paths.build_dir
     elif sys.platform != "win32":
-        cmd = 'make -C %s' % build_dir
+        cmd = 'make -C %s' % paths.build_dir
     else:
         cmd = 'tools\win_build.bat'
 
@@ -49,9 +29,9 @@ def build():
 
 def pkg():
     if sys.platform.find('freebsd') == 0:
-        cmd = 'BUILDTYPE=%s gmake -C %s pkg' % (BUILDTYPE, root)
+        cmd = 'BUILDTYPE=%s gmake -C %s pkg' % (paths.BUILDTYPE, paths.root)
     elif sys.platform != "win32":
-        cmd = 'BUILDTYPE=%s make -C %s pkg' % (BUILDTYPE, root)
+        cmd = 'BUILDTYPE=%s make -C %s pkg' % (paths.BUILDTYPE, paths.root)
     else:
         cmd = 'tools\win_pkg.bat'
 
@@ -61,9 +41,9 @@ def pkg():
 
 def pkg_sign():
     if sys.platform.find('freebsd') == 0:
-        cmd = 'BUILDTYPE=%s gmake -C %s pkg-sign' % (BUILDTYPE, root)
+        cmd = 'BUILDTYPE=%s gmake -C %s pkg-sign' % (paths.BUILDTYPE, paths.root)
     elif sys.platform != "win32":
-        cmd = 'BUILDTYPE=%s make -C %s pkg-sign' % (BUILDTYPE, root)
+        cmd = 'BUILDTYPE=%s make -C %s pkg-sign' % (paths.BUILDTYPE, paths.root)
     else:
         print 'win32 not supported skipping packaging'
         sys.exit(0)
@@ -73,17 +53,17 @@ def pkg_sign():
 
 
 def test_cmd(additional=""):
-    state_config = os.path.join(root, 'contrib')
-    monitoring_config = os.path.join(root, 'agents', 'monitoring', 'tests', 'fixtures', 'monitoring-agent-localhost.cfg')
+    state_config = os.path.join(paths.root, 'contrib')
+    monitoring_config = os.path.join(paths.root, 'agents', 'monitoring', 'tests', 'fixtures', 'monitoring-agent-localhost.cfg')
 
-    return '%s -d -c %s -s %s %s' % (agent, monitoring_config, state_config, additional)
+    return '%s -d -c %s -s %s %s' % (paths.agent, monitoring_config, state_config, additional)
 
 
 def test(stdout=None, entry="tests"):
     if sys.platform != "win32":
-        agent_tests = os.path.join(root, 'out', BUILDTYPE, 'monitoring-test.zip')
+        agent_tests = os.path.join(paths.root, 'out', paths.BUILDTYPE, 'monitoring-test.zip')
     else:
-        agent_tests = os.path.join(root, BUILDTYPE, 'monitoring-test.zip')
+        agent_tests = os.path.join(paths.root, paths.BUILDTYPE, 'monitoring-test.zip')
 
     cmd = test_cmd("--zip %s -e %s" % (agent_tests, entry))
     print cmd

--- a/tools/paths.py
+++ b/tools/paths.py
@@ -1,0 +1,24 @@
+import sys
+import os
+
+agent = None
+luvit = None
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+build_dir = os.path.join(root, 'out')
+
+BUILDTYPE = os.environ.get('BUILDTYPE', 'Debug')
+
+if sys.platform != "win32":
+    agent = os.path.join(root, 'out', BUILDTYPE, 'monitoring-agent')
+else:
+    agent = os.path.join(root, BUILDTYPE, 'monitoring-agent.exe')
+
+if sys.platform != "win32":
+    luvit = os.path.join(root, 'out', BUILDTYPE, 'luvit')
+else:
+    luvit = os.path.join(root, BUILDTYPE, 'luvit.exe')
+
+if __name__ == "__main__":
+    os.environ['AGENT_BIN'] = agent
+    os.environ['LUVIT_BIN'] = luvit


### PR DESCRIPTION
paths.py will either export the LUVIT_BIN and AGENT_BIN environment
variables if ran or will put these variables into fields in the module.

I needed to do this because I want to be able to run the runner script
outside of tools/build.py
