### PR TITLE
change source field to be a guid

### DIFF
--- a/agents/monitoring/default/client/client.lua
+++ b/agents/monitoring/default/client/client.lua
@@ -43,6 +43,7 @@ function AgentClient:initialize(options, scheduler)
   self._datacenter = options.datacenter
   self._id = options.id
   self._token = options.token
+  self._guid = options.guid
   self._target = 'endpoint'
   self._host = options.host
   self._port = options.port
@@ -106,7 +107,7 @@ function AgentClient:connect()
     self:emit('connect')
 
     -- setup protocol
-    self.protocol = AgentProtocolConnection:new(self._log, self._id, self._token, cleartext)
+    self.protocol = AgentProtocolConnection:new(self._log, self._id, self._token, self._guid, cleartext)
     self.protocol:on('error', function(err)
       -- set self.rateLimitReached so reconnect logic stops
       -- if close event is emitted before this message event

--- a/agents/monitoring/default/client/connection_stream.lua
+++ b/agents/monitoring/default/client/connection_stream.lua
@@ -30,9 +30,10 @@ local misc = require('../util/misc')
 local vtime = require('virgo-time')
 
 local ConnectionStream = Emitter:extend()
-function ConnectionStream:initialize(id, token, options)
+function ConnectionStream:initialize(id, token, guid, options)
   self._id = id
   self._token = token
+  self._guid = guid
   self._clients = {}
   self._unauthedClients = {}
   self._delays = {}
@@ -227,6 +228,7 @@ function ConnectionStream:createConnection(options, callback)
   local opts = misc.merge({
     id = self._id,
     token = self._token,
+    guid = self._guid,
     timeout = consts.CONNECT_TIMEOUT
   }, options)
 

--- a/agents/monitoring/default/protocol/connection.lua
+++ b/agents/monitoring/default/protocol/connection.lua
@@ -96,7 +96,7 @@ responses['check.test'] = function(self, request, callback)
   end)
 end
 
-function AgentProtocolConnection:initialize(log, myid, token, conn)
+function AgentProtocolConnection:initialize(log, myid, token, guid, conn)
   assert(conn ~= nil)
   assert(myid ~= nil)
 
@@ -113,6 +113,7 @@ function AgentProtocolConnection:initialize(log, myid, token, conn)
   self._completions = {}
   self._requests = requests
   self._responses = responses
+  self._guid = guid
   self.HANDSHAKE_TIMEOUT = HANDSHAKE_TIMEOUT
   self:setState(STATES.INITIAL)
 end
@@ -199,7 +200,7 @@ function AgentProtocolConnection:_completionKey(...)
   local source = nil
 
   if #args == 1 then
-    source = self._myid
+    source = self._guid
     msgid = args[1]
   elseif #args == 2 then
     source = args[1]
@@ -213,7 +214,7 @@ end
 
 function AgentProtocolConnection:_send(msg, timeout, expectedCode, callback)
   msg.target = 'endpoint'
-  msg.source = self._myid
+  msg.source = self._guid
   local msg_str = JSON.stringify(msg)
   local data = msg_str .. '\n'
   local key = self:_completionKey(msg.target, msg.id)

--- a/agents/monitoring/tests/net/init.lua
+++ b/agents/monitoring/tests/net/init.lua
@@ -42,7 +42,7 @@ exports['test_reconnects'] = function(test, asserts)
     datacenter = 'test',
     tls = { rejectUnauthorized = false }
   }
-  local client = ConnectionStream:new('id', 'token', options)
+  local client = ConnectionStream:new('id', 'token', 'guid', options)
 
   local errorCount = 0
   client:on('error', function(err)


### PR DESCRIPTION
_ready for review_
- Protocol source field has been changed to a GUID.
- This will allow us in the AEP endpoint to look at the source and see if a duplicate agent is connected.

Depends on https://github.com/racker/rackspace-monitoring/pull/8
Depends on https://github.com/racker/ele/pull/961
