### PR TITLE
tools: pkgutils: fix pkg_dir for linux

### DIFF
--- a/tools/pkgutils.py
+++ b/tools/pkgutils.py
@@ -35,7 +35,9 @@ def pkg_dir():
         dist = platform.dist()
         # Lower case everyting (looking at you Ubuntu)
         dist = tuple([x.lower() for x in dist])
-        addon = "-%s-%s" % dist[:2]
+        dist = "%s-%s" % dist[:2]
+        return "%s-%s" % (dist, machine)
+
     return "%s-%s%s" % (system, machine, addon)
 
 


### PR DESCRIPTION
pkg_dir() is creating ugly names for linux distros which is making the
URLs ugly too:

```
linux-x86_64-ubuntu-10.04
```

change it to return something like:

```
ubuntu-10.04-x86_64
```
