### PR TITLE
Map errors to original file

### DIFF
--- a/agents/monitoring/init.lua
+++ b/agents/monitoring/init.lua
@@ -55,9 +55,36 @@ function Entry.run()
   end)
 
   if err == false then
+    local lookup_err, original_path
+    lookup_err, original_path = pcall(lookup_path, msg)
+    if original_path then
+      msg = original_path .. ' -> ' .. msg
+    else
+      logging.debug("couldn't look up the original path for " .. mod .. original_path)
+    end
     logging.error(msg)
     process.exit(1)
   end
 end
 
+function lookup_path(file_path)
+  local mapping = require('./path_mapping')
+  
+  local delim = ".lua"
+
+  -- NOTE- not very robust, but lua error messages here start with the 
+  -- lua path ending with a .lua.  Relative imports would be broken
+  local top_level_error_path = file_path:find("(" .. delim .. ")")
+  if not top_level_error_path then 
+    return 
+  end
+
+  local lua_module = file_path:sub(0, top_level_error_path + #delim -1)
+
+  local original_path = mapping[lua_module]
+  if original_path then
+    return original_path
+  end
+
+end
 return Entry

--- a/tools/lua2zip.py
+++ b/tools/lua2zip.py
@@ -1,64 +1,91 @@
 #!/usr/bin/env python
-#
-#
 
 import sys
 import os
 from bundle import generate_bundle_map
 from zipfile import ZipFile, ZIP_DEFLATED
 
-lib_lua = os.path.join('lib', 'lua')
-async_lua = os.path.join('modules', 'async')
-bourbon_lua = os.path.join('modules', 'bourbon')
-options_lua = os.path.join('modules', 'options')
-traceroute_lua = os.path.join('modules', 'traceroute')
-line_emitter_lua = os.path.join('modules', 'line-emitter')
-rackspace_monitoring_client_lua = os.path.join('modules', 'luvit-rackspace-monitoring-client')
-luvit_keystone_client_lua = os.path.join('modules', 'luvit-keystone-client')
-luvit_lua = os.path.join('deps', 'luvit', 'lib', 'luvit')
-monitoring_lua = os.path.join('agents', 'monitoring', 'default')
-collector_lua = os.path.join('agents', 'monitoring', 'collector')
-crash_lua = os.path.join('agents', 'monitoring', 'crash')
-monitoring_tests = os.path.join('agents', 'monitoring', 'tests')
 
-modules = {
-    async_lua:
-        generate_bundle_map('modules/async', 'modules/async'),
-    bourbon_lua:
-        generate_bundle_map('modules/bourbon', 'modules/bourbon'),
-    options_lua:
-        generate_bundle_map('modules/options', 'modules/options'),
-    traceroute_lua:
-        generate_bundle_map('modules/traceroute', 'modules/traceroute'),
-    line_emitter_lua:
-        generate_bundle_map('modules/line-emitter', 'modules/line-emitter'),
-    luvit_keystone_client_lua:
-        generate_bundle_map('modules/keystone', 'modules/luvit-keystone-client'),
-    rackspace_monitoring_client_lua:
-        generate_bundle_map('modules/rackspace-monitoring', 'modules/luvit-rackspace-monitoring-client'),
-    lib_lua:
-        generate_bundle_map('', 'lib/lua', True),
-    luvit_lua:
-        generate_bundle_map('', 'deps/luvit/lib/luvit', True),
-    monitoring_lua:
-        generate_bundle_map('modules/monitoring/default', 'agents/monitoring/default'),
-    collector_lua:
-        generate_bundle_map('modules/monitoring/collector', 'agents/monitoring/collector'),
-    monitoring_tests:
-        generate_bundle_map('modules/monitoring/tests', 'agents/monitoring/tests'),
-    crash_lua:
-        generate_bundle_map('modules/monitoring/crash', 'agents/monitoring/crash'),
-}
+class VirgoZip(ZipFile):
+    lua_table_style = " return {\n%s\n}"
 
-target = sys.argv[1]
-sources = sys.argv[2:]
+    def __init__(self, *args, **kwargs):
+        ZipFile.__init__(self, *args, **kwargs)
+        self.mapping = {}
 
-z = ZipFile(target, 'w', ZIP_DEFLATED)
-for source in sources:
-    if os.path.isdir(source):
+    def add(self, source, target):
+        self.write(source, target)
+        self.mapping[target] = source
+
+    def to_lua(self):
+        """make a lua importable file so we can trace these files
+        to where they come from for easier debugging"""
+        lua_syntax_list = [('  ["/%s"] = "%s"') % (key, val) for key, val in self.mapping.iteritems()]
+        stringified = ",\n".join(lua_syntax_list)
+        return self.lua_table_style % (stringified)
+
+    def add_mapping_file(self):
+        self.writestr('path_mapping.lua', self.to_lua())
+
+
+def main():
+    lib_lua = os.path.join('lib', 'lua')
+    async_lua = os.path.join('modules', 'async')
+    bourbon_lua = os.path.join('modules', 'bourbon')
+    options_lua = os.path.join('modules', 'options')
+    traceroute_lua = os.path.join('modules', 'traceroute')
+    line_emitter_lua = os.path.join('modules', 'line-emitter')
+    rackspace_monitoring_client_lua = os.path.join('modules', 'luvit-rackspace-monitoring-client')
+    luvit_keystone_client_lua = os.path.join('modules', 'luvit-keystone-client')
+    luvit_lua = os.path.join('deps', 'luvit', 'lib', 'luvit')
+    monitoring_lua = os.path.join('agents', 'monitoring', 'default')
+    collector_lua = os.path.join('agents', 'monitoring', 'collector')
+    crash_lua = os.path.join('agents', 'monitoring', 'crash')
+    monitoring_tests = os.path.join('agents', 'monitoring', 'tests')
+
+    modules = {
+        async_lua:
+            generate_bundle_map('modules/async', 'modules/async'),
+        bourbon_lua:
+            generate_bundle_map('modules/bourbon', 'modules/bourbon'),
+        options_lua:
+            generate_bundle_map('modules/options', 'modules/options'),
+        traceroute_lua:
+            generate_bundle_map('modules/traceroute', 'modules/traceroute'),
+        line_emitter_lua:
+            generate_bundle_map('modules/line-emitter', 'modules/line-emitter'),
+        luvit_keystone_client_lua:
+            generate_bundle_map('modules/keystone', 'modules/luvit-keystone-client'),
+        rackspace_monitoring_client_lua:
+            generate_bundle_map('modules/rackspace-monitoring', 'modules/luvit-rackspace-monitoring-client'),
+        lib_lua:
+            generate_bundle_map('', 'lib/lua', True),
+        luvit_lua:
+            generate_bundle_map('', 'deps/luvit/lib/luvit', True),
+        monitoring_lua:
+            generate_bundle_map('modules/monitoring/default', 'agents/monitoring/default'),
+        collector_lua:
+            generate_bundle_map('modules/monitoring/collector', 'agents/monitoring/collector'),
+        monitoring_tests:
+            generate_bundle_map('modules/monitoring/tests', 'agents/monitoring/tests'),
+        crash_lua:
+            generate_bundle_map('modules/monitoring/crash', 'agents/monitoring/crash'),
+    }
+
+    target = sys.argv[1]
+    sources = sys.argv[2:]
+
+    z = VirgoZip(target, 'w', ZIP_DEFLATED)
+    for source in sources:
+        if not os.path.isdir(source):
+            z.add(source, os.path.basename(source))
+            continue
         if source in modules:
             for mod_file in modules[source]:
-                z.write(mod_file['os_filename'], mod_file['bundle_filename'])
-    else:
-        z.write(source, os.path.basename(source))
-z.close()
+                z.add(mod_file['os_filename'], mod_file['bundle_filename'])
+
+    z.add_mapping_file()
+    z.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Its nice to now where the errors in modules/path/module.lua actually lives on disk before it is zipped.  This is an ok first step without stepping into Luvit.  Tests pass.  
