### PR TITLE
fix multiple agent connections from being spawned

### DIFF
--- a/agents/monitoring/default/client/client.lua
+++ b/agents/monitoring/default/client/client.lua
@@ -51,7 +51,6 @@ function AgentClient:initialize(options, scheduler)
   self._host = options.host
   self._port = options.port
   self._timeout = options.timeout or 5000
-  self._reconnecting = false
 
   if DATACENTER_COUNT[options.datacenter] then
     DATACENTER_COUNT[options.datacenter] = DATACENTER_COUNT[options.datacenter] + 1
@@ -170,15 +169,6 @@ end
 
 function AgentClient:isDestroyed()
   return self._destroyed
-end
-
-function AgentClient:setReconnecting()
-  self._reconnecting = true
-end
-
-
-function AgentClient:isReconnecting()
-  return self._reconnecting
 end
 
 function AgentClient:startHeartbeatInterval()

--- a/agents/monitoring/default/client/connection_stream.lua
+++ b/agents/monitoring/default/client/connection_stream.lua
@@ -132,11 +132,10 @@ options - passed to ConnectionStream:reconnect
 callback - Callback called with (err)
 ]]--
 function ConnectionStream:restart(client, options, callback)
-  if client:isReconnecting() then
+  if client:isDestroyed() then
     return
   end
 
-  client:setReconnecting()
   client:destroy()
 
   -- Find a new client to handle time sync


### PR DESCRIPTION
- Add an ID to each connection
- Fixes a race in the keepalive logic to see if the client has been destroyed
