### PR TITLE
monitoring: fix monitoring init to catch version

### DIFF
--- a/agents/monitoring/monitoring.c
+++ b/agents/monitoring/monitoring.c
@@ -150,6 +150,17 @@ int main(int argc, char* argv[])
   /* Setup Lua Contexts for Luvit and Libuv runloop */
   err = virgo_init(v);
   if (err) {
+    if (err->err == VIRGO_EHELPREQ) {
+      show_help();
+      virgo_error_clear(err);
+      return 0;
+    }
+    else if (err->err == VIRGO_EVERSIONREQ) {
+      show_version(v);
+      virgo_error_clear(err);
+      return 0;
+    }
+
     handle_error("Error in init", err);
     return EXIT_FAILURE;
   }
@@ -163,19 +174,7 @@ int main(int argc, char* argv[])
   /* Enter Luvit and Execute */
   err = virgo_run(v);
   if (err) {
-    if (err->err == VIRGO_EHELPREQ) {
-      show_help();
-      virgo_error_clear(err);
-      return 0;
-    }
-    else if (err->err == VIRGO_EVERSIONREQ) {
-      show_version(v);
-      virgo_error_clear(err);
-      return 0;
-    }
-    else {
-      handle_error("Runtime Error", err);
-    }
+    handle_error("Runtime Error", err);
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
virgo_init now takes care of the --help and --version check. Move the
logic to check for those flags after that call.
