### PR TITLE
lib: virgo_exec: fix arg copying for upgrade

### DIFF
--- a/lib/virgo_exec.c
+++ b/lib/virgo_exec.c
@@ -31,7 +31,7 @@
 
 static char**
 copy_args(virgo_t *v, const char *bundle_path) {
-  int i, index = 0;
+  int i, index = 1;
   char **args;
 
   args = malloc((v->argc + 10) * sizeof(char*));
@@ -55,10 +55,11 @@ copy_args(virgo_t *v, const char *bundle_path) {
 extern char **environ;
 
 static virgo_error_t*
-virgo__exec(virgo_t *v, const char *exe_path, const char *bundle_path) {
+virgo__exec(virgo_t *v, char *exe_path, const char *bundle_path) {
   char **args = copy_args(v, bundle_path);
   int rc;
 
+  args[0] = exe_path;
   rc = execve(exe_path, args, environ);
   if (rc < 0) { /* on success, does not execute */
     return virgo_error_createf(VIRGO_ENOFILE, "execve failed errno=%i", errno);


### PR DESCRIPTION
argv[0] of the new agent was getting set to argv[1] of the old agent.
This meant we lost the first flag given to the agent and also set the
agent binary name to something unrealistic. Fix this by starting the
indexing at 1 and putting exe_name into args[0].
