### PR TITLE
Refactoring:

### DIFF
--- a/agents/monitoring/default/endpoint.lua
+++ b/agents/monitoring/default/endpoint.lua
@@ -1,0 +1,44 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+local Object = require('core').Object
+local fmt = require('string').format
+local misc = require('./util/misc')
+local logging = require('./util/logging')
+
+local Endpoint = Object:extend()
+
+function Endpoint:initialize(host, port)
+  if host and port then
+    self.host = host
+    self.port = port
+  else
+    ip_and_port = misc.splitAddress(host)
+    self.host = ip_and_port[1]
+    self.port = ip_and_port[2]
+  end
+
+  if not self.host or not self.port then
+    logging.error("No endpoint could be found")
+    process.exit(1)
+  end
+
+end
+
+function Endpoint.meta.__tostring(table)
+  return fmt("%s:%s", table.host, table.port)
+end
+
+return {Endpoint=Endpoint}

--- a/agents/monitoring/default/init.lua
+++ b/agents/monitoring/default/init.lua
@@ -14,254 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 --]]
 
-
-local async = require('async')
-local string = require('string')
-local utils = require('utils')
-local JSON = require('json')
-local Object = require('core').Object
-local fmt = require('string').format
-local logging = require('logging')
-local timer = require('timer')
-local dns = require('dns')
-local fs = require('fs')
-local os = require('os')
-local path = require('path')
-local Emitter = require('core').Emitter
-local vtime = require('virgo-time')
-
-local sigarCtx = require('./sigar').ctx
-
-local ConnectionStream = require('./client/connection_stream').ConnectionStream
-local CrashReportSubmitter = require('./crashreport').CrashReportSubmitter
-local constants = require('./util/constants')
-local misc = require('./util/misc')
-local States = require('./states')
-local stateFile = require('./state_file')
-local fsutil = require('./util/fs')
-local UUID = require('./util/uuid')
+local MonitoringAgent = require('./monitoring_agent').MonitoringAgent
 local Setup = require('./setup').Setup
+local constants = require('./util/constants')
 
-local table = require('table')
-
-local MonitoringAgent = Emitter:extend()
-
-function MonitoringAgent:_queryForEndpoints(domains, callback)
-  local endpoints = ''
-  function iter(domain, callback)
-    dns.resolve(domain, 'SRV', function(err, results)
-      if err then
-        logging.error('Could not lookup SRV record from ' .. domain)
-        callback()
-        return
-      end
-      callback(nil, results)
-    end)
-  end
-  async.map(domains, iter, function(err, results)
-    local i, v, serverPort
-    for i, v in pairs(results) do
-      serverPort = results[i][1].name .. ':' .. results[i][1].port
-      endpoints = endpoints .. serverPort
-      logging.info('found endpoint: ' .. serverPort)
-      if i ~= #results then
-        endpoints = endpoints .. ','
-      end
-    end
-    callback(nil, endpoints)
-  end)
-end
-
-function MonitoringAgent:_getSystemId()
-  local netifs = sigarCtx:netifs()
-  for i=1, #netifs do
-    local eth = netifs[i]:info()
-    if eth['type'] ~= 'Local Loopback' then
-      return UUID:new(eth.hwaddr):toString()
-    end
-  end
-  return nil
-end
-
-function MonitoringAgent:_getPersistentFilename(variable)
-  return path.join(constants.DEFAULT_PERSISTENT_VARIABLE_PATH, variable .. '.txt')
-end
-
-function MonitoringAgent:_savePersistentVariable(variable, data, callback)
-  local filename = self:_getPersistentFilename(variable)
-  fsutil.mkdirp(constants.DEFAULT_PERSISTENT_VARIABLE_PATH, "0755", function(err)
-    if err and err.code ~= 'EEXIST' then
-      callback(err)
-      return
-    end
-    fs.writeFile(filename, data, function(err)
-      callback(err, filename)
-    end)
-  end)
-end
-
-function MonitoringAgent:_getPersistentVariable(variable, callback)
-  local filename = self:_getPersistentFilename(variable)
-  fs.readFile(filename, function(err, data)
-    if err then
-      callback(err)
-      return
-    end
-    callback(nil, misc.trim(data))
-  end)
-end
-
-function MonitoringAgent:setConfig(config)
-  self._config = config
-end
-
-function MonitoringAgent:_verifyState(callback)
-
-  if self._config['monitoring_token'] == nil then
-    logging.error("'monitoring_token' is missing from 'config'")
-    process.exit(1)
-  end
-
-  -- Regen GUID
-  self._config['monitoring_guid'] = self:_getSystemId()
-
-  async.series({
-    -- retrieve persistent variables
-    function(callback)
-      if self._config['monitoring_id'] ~= nil then
-        callback()
-        return
-      end
-
-      self:_getPersistentVariable('monitoring_id', function(err, monitoring_id)
-        local getSystemId
-        getSystemId = function(callback)
-          monitoring_id = self:_getSystemId()
-          if not monitoring_id then
-            logging.error("could not retrieve system id... retrying")
-            timer.setTimeout(5000, getSystemId)
-            return
-          end
-          self._config['monitoring_id'] = monitoring_id
-          self:_savePersistentVariable('monitoring_id', monitoring_id, callback)
-        end
-
-        if err and err.code ~= 'ENOENT' then
-          callback(err)
-          return
-        elseif err and err.code == 'ENOENT' then
-          getSystemId(callback)
-        else
-          self._config['monitoring_id'] = monitoring_id
-          callback()
-        end
-      end)
-    end,
-    -- log
-    function(callback)
-      logging.debug('Using monitoring_id ' .. self._config['monitoring_id'])
-      logging.debug('Using monitoring_guid ' .. self._config['monitoring_guid'])
-      callback()
-    end
-  }, callback)
-end
-
-function MonitoringAgent:_loadEndpoints(callback)
-  local endpoints
-  local query_endpoints
-
-  if not self._config['monitoring_query_endpoints'] then
-    self._config['monitoring_query_endpoints'] = table.concat(constants.DEFAULT_MONITORING_SRV_QUERIES, ',')
-  end
-
-  if self._config['monitoring_query_endpoints'] and
-     self._config['monitoring_endpoints'] == nil then
-    -- Verify that the endpoint addresses are specified in the correct format
-    query_endpoints = misc.split(self._config['monitoring_query_endpoints'], '[^,]+')
-    logging.debug("querying for endpoints: ".. self._config['monitoring_query_endpoints'])
-    self:_queryForEndpoints(query_endpoints, function(err, endpoints)
-      if err then
-        callback(err)
-        return
-      end
-      self._config['monitoring_endpoints'] = endpoints
-      callback()
-    end)
-  else
-    -- Verify that the endpoint addresses are specified in the correct format
-    endpoints = misc.split(self._config['monitoring_endpoints'], '[^,]+')
-    if #endpoints == 0 then
-      logging.error("at least one endpoint needs to be specified")
-      process.exit(1)
-    end
-    for i, address in ipairs(endpoints) do
-      if misc.splitAddress(address) == nil then
-        logging.error("endpoint needs to be specified in the following format ip:port")
-        process.exit(1)
-      end
-    end
-    callback()
-  end
-end
-
-function MonitoringAgent:loadStates(callback)
-  async.series({
-    -- Load the States
-    function(callback)
-      self._states:load(callback)
-    end,
-    -- Verify
-    function(callback)
-      self:_verifyState(callback)
-    end,
-    function(callback)
-      self:_loadEndpoints(callback)
-    end
-  }, callback)
-end
-
-function MonitoringAgent:connect(callback)
-  local endpoints = misc.split(self._config['monitoring_endpoints'], '[^,]+')
-  if #endpoints <= 0 then
-    logging.error('no endpoints')
-    timer.setTimeout(misc.calcJitter(constants.SRV_RECORD_FAILURE_DELAY, constants.SRV_RECORD_FAILURE_DELAY_JITTER), function()
-      process.exit(1)
-    end)
-    return
-  end
-  self._streams = ConnectionStream:new(self._config['monitoring_id'],
-                                       self._config['monitoring_token'],
-                                       self._config['monitoring_guid'],
-                                       self._options)
-  self._streams:on('error', function(err)
-    logging.error(JSON.stringify(err))
-  end)
-  self._streams:on('promote', function()
-    self:emit('promote')
-  end)
-  self._streams:createConnections(endpoints, callback)
-end
-
-function MonitoringAgent:getStreams()
-  return self._streams
-end
-
-function MonitoringAgent:initialize(options)
-  if not options.stateDirectory then
-    options.stateDirectory = constants.DEFAULT_STATE_PATH
-  end
-  logging.debug('Using state directory ' .. options.stateDirectory)
-  self._stateDirectory = options.stateDirectory
-  self._states = States:new(options.stateDirectory)
-  self._config = virgo.config
-  self._options = options
-end
-
-function MonitoringAgent:getConfig()
-  return self._config
-end
-
-function MonitoringAgent.run(argv)
+local function main(argv)
   argv = argv and argv or {}
   local options = {}
 
@@ -269,25 +26,29 @@ function MonitoringAgent.run(argv)
     options.stateDirectory = argv.s
   end
 
-  if argv.c then
-    options.configFile = argv.c
-  end
+  options.configFile = argv.c or constants.DEFAULT_CONFIG_PATH
 
   if argv.p then
     options.pidFile = argv.p
   end
 
   if argv.i then
-    local caCertsDebug = require('./certs').caCertsDebug
     options.tls = {
       rejectUnauthorized = true,
-      ca = caCertsDebug
+      ca = require('./certs').caCertsDebug
     }
   end
 
   local agent = MonitoringAgent:new(options)
 
   -- setup will exit and not fall through
+  if not argv.u then
+    return agent:start(options)
+  end
+
+  Setup:new(argv, options.configFile, agent):run()
+
+
   if argv.u then
     options.configFile = options.configFile or constants.DEFAULT_CONFIG_PATH
     local setup = Setup:new(argv, options.configFile, agent)
@@ -297,76 +58,6 @@ function MonitoringAgent.run(argv)
   end
 end
 
-function MonitoringAgent:_sendCrashReports(callback)
-  local crashReports = {}
-  local productName = virgo.default_name:gsub('%-', '%%%-')
-
-  -- TODO: crash report support on !Linux platforms.
-  if os.type() ~= 'Linux' then
-    callback()
-    return
-  end
-
-  local function submitCrashReport(filename, callback)
-    filename = "/tmp/" .. filename
-    local crs = CrashReportSubmitter:new(filename, constants.CRASH_REPORT_URL)
-    crs:run(function (err)
-      if (err) then
-        callback(err)
-        return
-      end
-      fs.unlink(filename, callback)
-    end)
-  end
-
-  async.series({
-    function(callback)
-      fs.readdir("/tmp", function (err, files)
-        if err then
-          callback(err)
-          return
-        end
-
-        for index,value in ipairs(files) do
-          if string.find(value, productName .. "%-crash%-report-.+.dmp") ~= nil then
-            logging.info('Found previous crash report /tmp/' .. value)
-            table.insert(crashReports, value)
-          end
-        end
-        callback()
-      end)
-    end,
-    function(callback)
-      async.forEachSeries(crashReports, submitCrashReport, callback)
-    end
-  }, callback)
-end
-
-function MonitoringAgent:start(options)
-  if self:getConfig() == nil then
-    logging.error("config missing or invalid")
-    process.exit(1)
-  end
-
-  async.series({
-    function(callback)
-      self:_sendCrashReports(callback)
-    end,
-    function(callback)
-      misc.writePid(options.pidFile, callback)
-    end,
-    function(callback)
-      self:loadStates(callback)
-    end,
-    function(callback)
-      self:connect(callback)
-    end
-  },
-  function(err)
-    if err then
-      logging.error(err.message)
-    end
-  end)
-end
-
-return MonitoringAgent
+return {
+  run = main
+}

--- a/agents/monitoring/default/monitoring_agent.lua
+++ b/agents/monitoring/default/monitoring_agent.lua
@@ -1,0 +1,386 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local string = require('string')
+local utils = require('utils')
+local JSON = require('json')
+local timer = require('timer')
+local dns = require('dns')
+local fs = require('fs')
+local os = require('os')
+local path = require('path')
+local table = require('table')
+
+local fmt = require('string').format
+local Emitter = require('core').Emitter
+
+local async = require('async')
+local sigarCtx = require('./sigar').ctx
+
+local constants = require('./util/constants')
+local misc = require('./util/misc')
+local States = require('./states')
+local stateFile = require('./state_file')
+local fsutil = require('./util/fs')
+local UUID = require('./util/uuid')
+local logging = require('logging')
+local vtime = require('virgo-time')
+
+local Endpoint = require('./endpoint').Endpoint
+local ConnectionStream = require('./client/connection_stream').ConnectionStream
+local CrashReportSubmitter = require('./crashreport').CrashReportSubmitter
+
+
+local MonitoringAgent = Emitter:extend()
+
+function MonitoringAgent:initialize(options)
+  if not options.stateDirectory then
+    options.stateDirectory = constants.DEFAULT_STATE_PATH
+  end
+  logging.debug('Using state directory ' .. options.stateDirectory)
+  self._stateDirectory = options.stateDirectory
+  self._states = States:new(options.stateDirectory)
+  self._config = virgo.config
+  self._options = options
+end
+
+function MonitoringAgent:start(options)
+  if self:getConfig() == nil then
+    logging.error("config missing or invalid")
+    process.exit(1)
+  end
+
+  async.series({
+    function(callback)
+      self:_sendCrashReports(callback)
+    end,
+    function(callback)
+      misc.writePid(options.pidFile, callback)
+    end,
+    function(callback)
+      self:loadStates(callback)
+    end,
+    function(callback)
+      self:connect(callback)
+    end
+  },
+  function(err)
+    if err then
+      logging.error(err.message)
+    end
+  end)
+end
+
+function MonitoringAgent:loadStates(callback)
+  async.series({
+    -- Load the States
+    function(callback)
+      self._states:load(callback)
+    end,
+    -- Verify
+    function(callback)
+      self:_verifyState(callback)
+    end,
+    function(callback)
+      self:_loadEndpoints(callback)
+    end
+  }, callback)
+end
+
+function MonitoringAgent:connect(callback)
+  local endpoints = self._config['monitoring_endpoints']
+  if #endpoints <= 0 then
+    logging.error('no endpoints')
+    timer.setTimeout(misc.calcJitter(constants.SRV_RECORD_FAILURE_DELAY, constants.SRV_RECORD_FAILURE_DELAY_JITTER), function()
+      process.exit(1)
+    end)
+    return
+  end
+  self._streams = ConnectionStream:new(self._config['monitoring_id'],
+                                       self._config['monitoring_token'],
+                                       self._config['monitoring_guid'],
+                                       self._options)
+  self._streams:on('error', function(err)
+    logging.error(JSON.stringify(err))
+  end)
+  self._streams:on('promote', function()
+    self:emit('promote')
+  end)
+  self._streams:createConnections(endpoints, callback)
+end
+
+function MonitoringAgent:getStreams()
+  return self._streams
+end
+
+function MonitoringAgent:getConfig()
+  return self._config
+end
+
+function MonitoringAgent:setConfig(config)
+  self._config = config
+end
+
+function MonitoringAgent:_verifyState(callback)
+
+  if self._config['monitoring_token'] == nil then
+    logging.error("'monitoring_token' is missing from 'config'")
+    process.exit(1)
+  end
+
+  -- Regen GUID
+  self._config['monitoring_guid'] = self:_getSystemId()
+
+  async.series({
+    -- retrieve persistent variables
+    function(callback)
+      if self._config['monitoring_id'] ~= nil then
+        callback()
+        return
+      end
+
+      self:_getPersistentVariable('monitoring_id', function(err, monitoring_id)
+        local getSystemId
+        getSystemId = function(callback)
+          monitoring_id = self:_getSystemId()
+          if not monitoring_id then
+            logging.error("could not retrieve system id... retrying")
+            timer.setTimeout(5000, getSystemId)
+            return
+          end
+          self._config['monitoring_id'] = monitoring_id
+          self:_savePersistentVariable('monitoring_id', monitoring_id, callback)
+        end
+
+        if err and err.code ~= 'ENOENT' then
+          callback(err)
+          return
+        elseif err and err.code == 'ENOENT' then
+          getSystemId(callback)
+        else
+          self._config['monitoring_id'] = monitoring_id
+          callback()
+        end
+      end)
+    end,
+    -- log
+    function(callback)
+      logging.debug('Using monitoring_id ' .. self._config['monitoring_id'])
+      logging.debug('Using monitoring_guid ' .. self._config['monitoring_guid'])
+      callback()
+    end
+  }, callback)
+end
+
+function MonitoringAgent:getStreams()
+  return self._streams
+end
+
+function MonitoringAgent:getConfig()
+  return self._config
+end
+
+function MonitoringAgent:setConfig(config)
+  self._config = config
+end
+
+function MonitoringAgent:_sendCrashReports(callback)
+  local crashReports = {}
+  local productName = virgo.default_name:gsub('%-', '%%%-')
+
+  -- backend doesn't yet support crash reports
+  if true then return callback() end
+  
+  -- TODO: crash report support on !Linux platforms.
+  if os.type() ~= 'Linux' then
+    callback()
+    return
+  end
+
+  local function send(file, callback)
+    async.series({
+      function(callback)
+        local options = {
+          method = "POST",
+          path = "/agent-crash-report"
+        }
+        self:https(options, nil, file, callback)
+      end,
+      function(callback)
+        fs.unlink(file, callback)
+      end
+      }, function(err, res)
+      if err then
+        logging.error('Error uploading crash report: ' .. file .. ' because '.. tostring(err))
+      end
+      callback()
+    end)
+  end
+
+  local dump_dir = virgo_paths.get(virgo_paths.VIRGO_PATH_PERSISTENT_DIR)
+
+  fs.readdir(dump_dir, function (err, files)
+    if err then
+      return callback(err)
+    end
+
+    local reports = {}
+    for _, file in ipairs(files) do
+      if string.find(file, productName .. "%-crash%-report-.+.dmp") ~= nil then
+        logging.info('Found previous crash report'.. dump_dir .. '/' .. file)
+        table.insert(reports, path.join(dump_dir, file))
+      end
+    end
+
+    async.forEachSeries(reports, send, function(err, res)
+      callback()
+    end)
+  end)
+end
+
+function MonitoringAgent:_loadEndpoints(callback)
+  local config = self._config
+  local queries = config['monitoring_query_endpoints'] or table.concat(constants.DEFAULT_MONITORING_SRV_QUERIES, ',')
+  local endpoints = config['monitoring_endpoints']
+
+  if queries and not endpoints then
+    queries = misc.split(queries, '[^,]+')
+
+    return self:_queryForEndpoints(queries, function(err, endpoints)
+      config['monitoring_endpoints'] = endpoints
+      callback(err, endpoints)
+    end)
+  end
+
+  -- split address,address,address
+  endpoints = misc.split(endpoints, '[^,]+')
+
+  if #endpoints == 0 then
+    logging.error("at least one endpoint needs to be specified")
+    process.exit(1)
+  end
+
+  local ip_and_port
+  local endpoints_found = {}
+
+  for _, address in ipairs(endpoints) do
+    table.insert(endpoints_found, Endpoint:new(address))
+  end
+
+  config['monitoring_endpoints'] = endpoints_found
+  callback(nil, endpoints_found)
+end
+
+function MonitoringAgent:_loadEndpoints(callback)
+  local config = self._config
+  local queries = config['monitoring_query_endpoints'] or table.concat(constants.DEFAULT_MONITORING_SRV_QUERIES, ',')
+  local endpoints = config['monitoring_endpoints']
+
+  if queries and not endpoints then
+    queries = misc.split(queries, '[^,]+')
+
+    return self:_queryForEndpoints(queries, function(err, endpoints)
+      config['monitoring_endpoints'] = endpoints
+      callback(err, endpoints)
+    end)
+  end
+
+  -- split address,address,address
+  endpoints = misc.split(endpoints, '[^,]+')
+
+  if #endpoints == 0 then
+    logging.error("at least one endpoint needs to be specified")
+    process.exit(1)
+  end
+
+  local address
+  local new_endpoints = {}
+
+  for _, address in ipairs(endpoints) do
+    table.insert(new_endpoints, Endpoint:new(address))
+  end
+
+  config['monitoring_endpoints'] = new_endpoints
+  callback(nil, new_endpoints)
+end
+
+function MonitoringAgent:_queryForEndpoints(domains, callback)
+  function iter(domain, callback)
+    dns.resolve(domain, 'SRV', function(err, results)
+      if err then
+        logging.error('Could not lookup SRV record from ' .. domain)
+        callback()
+        return
+      end
+      callback(nil, results)
+    end)
+  end
+  local endpoints_found = {}
+  async.map(domains, iter, function(err, results)
+    local endpoint, _
+    for _, endpoint in pairs(results) do
+      -- results are wrapped in a table...
+      endpoint = endpoint[1]
+      -- get anem and port
+      endpoint = Endpoint:new(endpoint.name, endpoint.port)
+      logging.info('found endpoint: ' .. tostring(endpoint))
+      table.insert(endpoints_found, endpoint)
+    end
+    callback(nil, endpoints_found)
+  end)
+end
+
+function MonitoringAgent:_getSystemId()
+  local netifs = sigarCtx:netifs()
+  for i=1, #netifs do
+    local eth = netifs[i]:info()
+    if eth['type'] ~= 'Local Loopback' then
+      return UUID:new(eth.hwaddr):toString()
+    end
+  end
+  return nil
+end
+
+function MonitoringAgent:_getPersistentFilename(variable)
+  return path.join(constants.DEFAULT_PERSISTENT_VARIABLE_PATH, variable .. '.txt')
+end
+
+function MonitoringAgent:_savePersistentVariable(variable, data, callback)
+  local filename = self:_getPersistentFilename(variable)
+  fsutil.mkdirp(constants.DEFAULT_PERSISTENT_VARIABLE_PATH, "0755", function(err)
+    if err and err.code ~= 'EEXIST' then
+      callback(err)
+      return
+    end
+    fs.writeFile(filename, data, function(err)
+      callback(err, filename)
+    end)
+  end)
+end
+
+function MonitoringAgent:_getPersistentVariable(variable, callback)
+  local filename = self:_getPersistentFilename(variable)
+  fs.readFile(filename, function(err, data)
+    if err then
+      callback(err)
+      return
+    end
+    callback(nil, misc.trim(data))
+  end)
+end
+
+return { MonitoringAgent = MonitoringAgent }
+

--- a/agents/monitoring/default/protocol/request.lua
+++ b/agents/monitoring/default/protocol/request.lua
@@ -1,0 +1,224 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local table = require('table')
+local https = require('https')
+local fs = require('fs')
+
+local logging = require('logging')
+local errors = require('../errors')
+local misc = require('../util/misc')
+
+local fmt = require('string').format
+local Object = require('core').Object
+
+local exports = {}
+
+local Request = Object:extend()
+
+--[[
+  options = {
+    host/port OR monitoring_endpoints
+    path = "string",
+    method = "METHOD"
+    upload = nil or '/some/path'
+    download = nil or '/some/path'
+    retries = nil or 3 or #monitoring_endpoints
+  }
+]]--
+function makeRequest(...)
+  return Request:new(...):request()
+end
+
+function Request:initialize(options, callback)
+  self.callback = misc.fireOnce(callback)
+
+  if not options.method then
+    return self.callback(errors.Error('I need a http method'))
+  end
+
+  -- shallow copy on endpoints to not permute the clients acutal endpoints
+  if options.monitoring_endpoints then
+    options.monitoring_endpoints = misc.merge({}, monitoring_endpoints)
+  end
+  -- endpoints are ip:port - we normally have multiples and its stupid to put this logic everywhere
+  self.options = options
+  self.retries = self:_set_host_and_port() or options.retries or 3
+
+  if not options.host or not options.port then
+    return self.callback(errors.Error('call with options.port and options.host or options.monitoring_endpoints'))
+  end
+
+  self.download = options.download
+  self.upload = options.upload
+  self.options.__headers_set = false
+end
+
+function Request:request()
+  if not self.options.__headers_set then
+    return self:_set_headers(function(err)
+      if err then
+        return self.callback(err)
+      end
+      self:request()
+    end)
+  end
+
+  logging.debug('sending request')
+
+  local req = https.request(self.options, function(res)
+    self:_handle_response(res)
+  end)
+
+  req:on('error', function(err)
+    self:_ensure_retries(err)
+  end)
+
+  if not self.upload_path then
+    return req:done()
+  end
+
+  local data = fs.createReadStream(self.upload_path)
+  data:on('data', function(d)
+    req:write(d)
+  end)
+  data:on('end', function(d)
+    req:done(d)
+  end)
+  data:on('error', function(err)
+    req:done()
+    self.callback(err)
+  end)
+end
+
+function Request:_set_host_and_port()
+  -- endpoints are ip:port - we normally have multiples
+  -- grab one- set retries to the remaining number
+  -- get a host if multiples were passed in
+  local retries, address
+
+  if not self.options.monitoring_endpoints or 
+    #self.options.monitoring_endpoints < 1 then
+    return
+  end
+
+  retries = #self.options.monitoring_endpoints
+  address = table.remove(self.options.monitoring_endpoints)
+  self.options.host = address[0]
+  self.options.port = address[1]
+
+  return retries
+
+end
+
+function Request:_set_headers(callback)
+  local method = self.options.method:upper()
+  local headers = {}
+
+  local _callback = function(...)
+    -- merge the headers into our options
+    self.options.headers = misc.merge(headers, self.options.headers)
+    self.options.__headers_set = true
+    callback(...)
+  end
+
+  -- set defaults
+  headers['Content-Length'] = 0
+  headers["Content-Type"] = "application/text"
+  if method == 'GET' or not self.upload_path then
+    return _callback()
+  end
+
+  -- set type on anything not a GET (including DELETE)
+  fs.stat(self.upload_path, function(err, stats)
+    if err then 
+      logging.error("couldn't stat file: " .. self.upload_path .. ' because ' .. tostring(err))
+      return _callback(err)
+    end
+    headers["Content-Type"] = "application/octet-stream"
+    headers['Content-Length'] = stats.size
+    return _callback()
+  end)
+end
+
+function Request:_write_stream(res)
+  loggind.debug('writing stream to disk: '.. self.download_path)
+
+  local stream = fs.createWriteStream(self.download_path)
+
+  stream:on('end', function()
+    self:_ensure_retries(nil, res)
+  end)
+
+  stream:on('error', function(err)
+    self:_ensure_retries(err, res)
+  end)
+
+  res:on('end', function(d)
+    stream:finish(d)
+  end)
+
+  res:pipe(stream)
+end
+
+function Request:_ensure_retries(err, res)
+  if not err then
+    return self.callback(err, res)
+  end
+  
+  local status = res and res.status_code or "?"
+  
+  local msg = fmt('%s request failed for %s with status: %s and error: %s', self.options.method or "?", 
+              self.download_path or self.upload_path or "?", status, tostring(err))
+
+  logging.warn(msg)
+
+  if self.retries > 0 then
+    self.retries = self.retries - 1
+    logging.debug('retrying download '.. self.retries .. ' more times.')
+
+    -- try a different data center if possible
+    self:_set_host_and_port()
+    return self:request()
+  end
+  
+  self.callback(err)
+end
+
+function Request:_handle_response(res)
+  logging.debug('res')
+
+  if res.status_code >= 400 then
+    return self:_ensure_retries(errors.Error:new("bad status"), res)
+  end
+
+  if self.download_path then
+    return self:_write_stream(res)
+  end
+
+  local buf = ""
+  res:on('data', function(d)
+    buf = buf .. d
+  end)
+
+  res:on('end', function()
+    logging.debug('got response: ' .. buf)
+    self:_ensure_retries(nil, res)
+  end)
+end
+
+local exports = {makeRequest=makeRequest, Request=Request}
+return exports

--- a/agents/monitoring/tests/net/init.lua
+++ b/agents/monitoring/tests/net/init.lua
@@ -1,9 +1,11 @@
+local table = require('table')
 local async = require('async')
 local ConnectionStream = require('monitoring/default/client/connection_stream').ConnectionStream
 local helper = require('../helper')
 local timer = require('timer')
 local fixtures = require('../fixtures')
 local constants = require('constants')
+local Endpoint = require('../../default/endpoint').Endpoint
 
 local exports = {}
 local child
@@ -44,7 +46,10 @@ exports['test_reconnects'] = function(test, asserts)
   local options = {
     datacenter = 'test',
     tls = { rejectUnauthorized = false },
-    stateDirectory = './tests'
+    stateDirectory = './tests',
+    host = "127.0.0.1",
+    port = 50061,
+    tls = { rejectUnauthorized = false }
   }
   local client = ConnectionStream:new('id', 'token', 'guid', options)
 
@@ -67,7 +72,12 @@ exports['test_reconnects'] = function(test, asserts)
     start_server,
     function(callback)
       client:on('handshake_success', counterTrigger(3, callback))
-      client:createConnections(fixtures.TESTING_AGENT_ENDPOINTS, function() end)
+      local endpoints = {}
+      for _, address in pairs(fixtures.TESTING_AGENT_ENDPOINTS) do
+        -- split ip:port 
+        table.insert(endpoints, Endpoint:new(address))
+      end
+      client:createConnections(endpoints, function() end)
     end,
     function(callback)
       stop_server(function()


### PR DESCRIPTION
We now have a generic http request wrapper than can uplaod/download files.

We shouldn't be spliting endpoint strings after load Endpoints is called as this is a verbose abstraction leak.  An Endpoint is now a table instead of a string.

Code should flow like so: initialization at the top, then public, then private.

Meaningful objects shouldn't live in init.lua because tracebacks are a long list of errors in different init.lua scripts which is really hard to read.

Options suffers from high pass through.  Everything gets, modifies, and passes them on which is bad.
