### PR TITLE
monitoring: host_info: delete a number of metrics

### DIFF
--- a/agents/monitoring/default/host_info.lua
+++ b/agents/monitoring/default/host_info.lua
@@ -60,8 +60,6 @@ function CPUInfo:initialize()
       'wait'
     }
     local info_fields = {
-      'cache_size',
-      'cores_per_socket',
       'mhz',
       'model',
       'total_cores',
@@ -87,12 +85,9 @@ function DiskInfo:initialize()
   HostInfo.initialize(self)
   local disks = sigarCtx:disks()
   local usage_fields = {
-    'queue',
     'read_bytes',
     'reads',
     'rtime',
-    'service_time',
-    'snaptime',
     'time',
     'write_bytes',
     'writes',
@@ -149,10 +144,8 @@ function NetworkInfo:initialize()
       'address',
       'address6',
       'broadcast',
-      'destination',
       'flags',
       'hwaddr',
-      'metric',
       'mtu',
       'name',
       'netmask',
@@ -164,7 +157,6 @@ function NetworkInfo:initialize()
       'rx_errors',
       'rx_overruns',
       'rx_dropped',
-      'rx_frame',
       'tx_packets',
       'tx_bytes',
       'tx_errors',
@@ -172,7 +164,6 @@ function NetworkInfo:initialize()
       'tx_dropped',
       'tx_collisions',
       'tx_carrier',
-      'speed'
     }
 
     if info then
@@ -233,10 +224,8 @@ function ProcessInfo:initialize()
       local proc_fields = {
         'name',
         'ppid',
-        'tty',
         'priority',
         'nice',
-        'processor',
         'threads'
       }
       for _, v in pairs(proc_fields) do
@@ -277,7 +266,6 @@ function FilesystemInfo:initialize()
       local info_fields = {
         'dir_name',
         'dev_name',
-        'type_name',
         'sys_type_name',
         'options',
       }
@@ -312,11 +300,7 @@ function SystemInfo:initialize()
   local obj = {name = sysinfo.name, arch = sysinfo.arch,
                version = sysinfo.version, vendor = sysinfo.vendor,
                vendor_version = sysinfo.vendor_version,
-               description = sysinfo.description}
-
-  if sysinfo.vendor_code_name ~= nil then
-    obj.vendor_code_name = sysinfo.vendor_code_name
-  end
+               vendor_name = sysinfo.vendor_name or sysinfo.vendor_version}
 
   table.insert(self._params, obj)
 end


### PR DESCRIPTION
a number of the metrics were just not useful. Delete them.
## cpu
- cache_size - This looked to be L2 cache size, doubtful people care
- cores_per_socket - no one cares about the number of cores per physical
  die
## disk
- queue, service_time - these seem buggy somehow. Sometimes they were
  showing up and other times they weren't. Plus they are dependent on
  the last time you called them. Just delete as I think the rtime and
  wtime give sufficient insight into the queue
- snaptime- this was the unix timestamp when the metric was snapped. We
  need a general hostinfo field for this.
## network
- destination - destination of the route, just seemed like a weird thing
  to have as it will always be the ip...
- metric - more routing stuff, not used by linux IIRC, delete it.
- speed - not implemented on linux, delete for now
## process
- tty - no one cares I think, delete
- processor - this is just going to bounce around in most configurations and not exist for all
  non-running processes, delete
## filesystem
- type_name - internally kept metric to sigar that is completely out of
  date.
## system
- Drop vendor_code_name, someone can wikipedia it if they want
- Add vendor_name
