### PR TITLE
lib: virgo_exec: add string.h

### DIFF
--- a/lib/virgo_exec.c
+++ b/lib/virgo_exec.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
 
 static char**
 copy_args(virgo_t *v, const char *bundle_path) {


### PR DESCRIPTION
../lib/virgo_exec.c: In function ‘copy_args’:
../lib/virgo_exec.c:40: warning: implicit declaration of function ‘strcmp’
../lib/virgo_exec.c:44: warning: implicit declaration of function ‘strdup’
