### PR TITLE
Makefile: don't build with V=1 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ sig_files = $(zip_files:%.zip=%.zip.sig)
 	-ln -fs out/${BUILDTYPE}/$@ $@
 
 all: out/Makefile
-	$(MAKE) -C out V=1 BUILDTYPE=$(BUILDTYPE) -j4
+	$(MAKE) -C out BUILDTYPE=$(BUILDTYPE) -j4
 	-ln -fs out/${BUILDTYPE}/monitoring-agent monitoring-agent
 	$(MAKE) $(sig_files) $(zip_files)
 


### PR DESCRIPTION
V=1 makes it hard to see warnings, stop doing that.
