### PR TITLE
monitoring: host_info: add timestamp field

### DIFF
--- a/agents/monitoring/default/host_info.lua
+++ b/agents/monitoring/default/host_info.lua
@@ -21,6 +21,7 @@ local fs = require('fs')
 local misc = require('./util/misc')
 local os = require('os')
 local table = require('table')
+local vtime = require('virgo-time')
 local sigarCtx = require('./sigar').ctx
 
 --[[ HostInfo ]]--
@@ -31,7 +32,8 @@ end
 
 function HostInfo:serialize()
   return {
-    metrics = self._params
+    metrics = self._params,
+    timestamp = vtime.now()
   }
 end
 


### PR DESCRIPTION
add a timestamp field to the host_info so we know at what time this
information was captured. This is useful for doing things like emulating
top using host_info since you know at what time the info came off the
host.
