### PR TITLE
monitoring: host_info: append swap_ on swap metrics

### DIFF
--- a/agents/monitoring/default/host_info.lua
+++ b/agents/monitoring/default/host_info.lua
@@ -139,7 +139,7 @@ function MemoryInfo:initialize()
   end
   if swapinfo then
     for _, k in pairs(swap_metrics) do
-      self._params[k] = swapinfo[k]
+      self._params['swap_' .. k] = swapinfo[k]
     end
   end
 end


### PR DESCRIPTION
follow the logic of the memory check and append swap_. This also fixes
the bug where the swap statistics were being reported as memory.
