### PR TITLE
Cleanup on tests

### DIFF
--- a/agents/monitoring/tests/helper.lua
+++ b/agents/monitoring/tests/helper.lua
@@ -1,9 +1,43 @@
 local spawn = require('childprocess').spawn
+local constants = require('constants')
+local misc = require('monitoring/default/util/misc')
 
 function runner(name)
   return spawn('python', {'agents/monitoring/runner.py', name})
 end
 
+local child
+
+local function start_server(callback)
+  local data = ''
+  callback = misc.fireOnce(callback)
+  child = runner('server_fixture_blocking')
+  child.stderr:on('data', function(d)
+    callback(d)
+  end)
+
+  child.stdout:on('data', function(chunk)
+    data = data .. chunk
+    if data:find('TLS fixture server listening on port 50061') then
+      callback()
+    end
+  end)
+
+  return child
+end
+
+local function stop_server(child)
+  if not child then return end
+  child:kill(constants.SIGUSR1) -- USR1
+end
+
+process:on('exit', function()
+  stop_server(child)
+end)
+
+
 local exports = {}
 exports.runner = runner
+exports.start_server = start_server
+exports.stop_server = stop_server
 return exports

--- a/agents/monitoring/tests/init.lua
+++ b/agents/monitoring/tests/init.lua
@@ -28,15 +28,16 @@ local exports = {}
 
 local failed = 0
 
-local tmp_dir = path.join('tests', 'tmp')
+_G['TEST_DIR'] = path.join(process.cwd(), 'tests', 'tmp')
+
 local function remove_tmp(callback)
-  fs.readdir(tmp_dir, function(err, files)
+  fs.readdir(TEST_DIR, function(err, files)
     if (files ~= nil) then
       for i, v in ipairs(files) do
-        fs.unlinkSync(path.join(tmp_dir, v))
+        fs.unlinkSync(path.join(TEST_DIR, v))
       end
     end
-    fs.rmdir(tmp_dir, callback)
+    fs.rmdir(TEST_DIR, callback)
   end)
 end
 
@@ -82,7 +83,7 @@ exports.run = function()
   -- bug that causes us to exit the loop early
   process.exitCode = 1
 
-  fs.mkdir(tmp_dir, "0755", function()
+  fs.mkdir(TEST_DIR, "0755", function()
     async.forEachSeries(TESTS_TO_RUN, runit, function(err)
       if err then
         p(err)


### PR DESCRIPTION
Try harder to close the spawned fixture server.  Makes the temp test dir a global, because its a global.
