### PR TITLE
pkg: monitoring: rpm: fix expect script on tcl 5.4

### DIFF
--- a/pkg/monitoring/rpm/rpm-sign.exp
+++ b/pkg/monitoring/rpm/rpm-sign.exp
@@ -1,10 +1,10 @@
 #!/usr/bin/expect -f
-  
+
 ### rpm-sign.exp -- Sign RPMs by sending the passphrase.
 
-spawn rpm --addsign {*}$argv
+eval spawn rpm --addsign $argv
 expect -exact "Enter pass phrase: "
 send -- "Secret passphrase\r"
 expect eof
-  
+
 ## end of rpm-sign.exp


### PR DESCRIPTION
tcl 5.4 doesn't have the {*} operator. Use eval and $args instead.
http://wiki.tcl.tk/17158
