### PR TITLE
monitoring: check: base: set status to success by default

### DIFF
--- a/agents/monitoring/default/check/base.lua
+++ b/agents/monitoring/default/check/base.lua
@@ -497,7 +497,7 @@ function CheckResult:initialize(check, options)
   self._options = options or {}
   self._metrics = {}
   self._state = 'available'
-  self._status = nil
+  self._status = 'success'
   self._check = check
   self:setTimestamp(self._options.timestamp)
   self._timestamp = vtime.now()


### PR DESCRIPTION
status gets set in setError to another value. So by default make the
status string "success".
