### PR TITLE
pkg: debian: package.init: detect upstart and use it

### DIFF
--- a/pkg/monitoring/debian/package.init
+++ b/pkg/monitoring/debian/package.init
@@ -17,6 +17,12 @@ LOG=/var/log/rackspace-monitoring-agent.log
 
 test -f $DAEMON || exit 0
 
+# If upstart is installed, use it instead
+if [ -x /lib/init/upstart-job ]; then
+        /lib/init/upstart-job rackspace-monitoring-agent $@
+        exit $?
+fi
+
 . /lib/lsb/init-functions
 
 case "$1" in


### PR DESCRIPTION
if upstart is installed then use /lib/init/upstart-job and exit so
people don't try using both sysv init and upstart and end up with two
processes
