### PR TITLE
monitoring: check: disk: filter disk targets

### DIFF
--- a/agents/monitoring/default/check/disk.lua
+++ b/agents/monitoring/default/check/disk.lua
@@ -19,6 +19,8 @@ local BaseCheck = require('./base').BaseCheck
 local CheckResult = require('./base').CheckResult
 local table = require('table')
 
+local sigarutil = require('monitoring/default/util/sigar')
+
 local DiskCheck = BaseCheck:extend()
 
 function DiskCheck:initialize(params)
@@ -32,12 +34,13 @@ function DiskCheck:initialize(params)
 end
 
 function DiskCheck:getTargets(callback)
-  local s = sigar:new()
-  local disks = s:disks()
+  local disks = sigarutil.diskTargets()
   local targets = {}
+
   for i=1, #disks do
     table.insert(targets, disks[i]:name())
   end
+
   callback(nil, targets)
 end
 

--- a/agents/monitoring/default/host_info.lua
+++ b/agents/monitoring/default/host_info.lua
@@ -22,7 +22,9 @@ local misc = require('./util/misc')
 local os = require('os')
 local table = require('table')
 local vtime = require('virgo-time')
+
 local sigarCtx = require('./sigar').ctx
+local sigarutil = require('monitoring/default/util/sigar')
 
 --[[ HostInfo ]]--
 local HostInfo = Object:extend()
@@ -85,7 +87,7 @@ end
 local DiskInfo = HostInfo:extend()
 function DiskInfo:initialize()
   HostInfo.initialize(self)
-  local disks = sigarCtx:disks()
+  local disks = sigarutil.diskTargets(sigarCtx)
   local usage_fields = {
     'read_bytes',
     'reads',

--- a/agents/monitoring/default/util/fs.lua
+++ b/agents/monitoring/default/util/fs.lua
@@ -3,6 +3,8 @@ local fs = require('fs')
 local table = require('table')
 local async = require('async')
 
+local sigarutil = require('monitoring/default/util/sigar')
+
 local exports = {}
 
 -- TODO: move to utils

--- a/agents/monitoring/default/util/sigar.lua
+++ b/agents/monitoring/default/util/sigar.lua
@@ -1,0 +1,46 @@
+--[[
+Copyright 2012 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local exports = {}
+
+local sigar = require('sigar')
+local os = require('os')
+local table = require('table')
+
+exports.diskTargets = function(sigarCtx)
+  local s = sigarCtx
+  if s == nil then
+    s = sigar:new()
+  end
+
+  local disks = s:disks()
+  local targets = {}
+  for i=1, #disks do
+    local name = disks[i]:name()
+
+    if os.type() == "win32" then
+      table.insert(targets, disks[i])
+    else
+      -- Only target real Unix disks for now
+      if name:find('/dev/') == 1 then
+        table.insert(targets, disks[i])
+      end
+    end
+  end
+  return targets
+end
+
+return exports


### PR DESCRIPTION
only target disks that are /dev/\* on UNIX.

This essentially blacklists all of the 'pseudo' block devices like rootfs, tmpfs, etc since they don't have any metrics anyways.
