### PR TITLE
R4R: tweak apache metric names

### DIFF
--- a/agents/monitoring/default/check/apache.lua
+++ b/agents/monitoring/default/check/apache.lua
@@ -133,7 +133,7 @@ function ApacheCheck:_parseLine(line, checkResult)
   end
 
   if f == 'ReqPerSec' then
-    checkResult:setStatus(fmt('requests_per_second: %.2f', v))
+    checkResult:setStatus(fmt('Handling %.2f requests per second', v))
   end
 
   if f == 'Scoreboard' then


### PR DESCRIPTION
Story: The Apache check should return metrics that are lower case and underscore separated.
