### PR TITLE
Fix all CPU percentage metrics as doubles

### DIFF
--- a/agents/monitoring/default/check/cpu.lua
+++ b/agents/monitoring/default/check/cpu.lua
@@ -174,7 +174,7 @@ function CpuCheck:run(callback)
     function(cpuinfo, metrics, callback)
       -- attach percentages and averages
       for key, value in pairs(metrics) do
-        checkResult:addMetric(key, nil, nil, value)
+        checkResult:addMetric(key, nil, 'double', value)
       end
       callback()
     end


### PR DESCRIPTION
We probably need to do this for a few other check types, but CPU is the worst offender. If the percentage happens to be an integer (especially 0) the type is reported as "int64" for that iteration, even though it should be a double.
