### PR TITLE
pkg: monitoring: debian: workaround service braindamage

### DIFF
--- a/pkg/monitoring/debian/postinst
+++ b/pkg/monitoring/debian/postinst
@@ -5,8 +5,8 @@ case "$1" in
     configure)
          # Restart only if we find a config file in place
          if [ -f /etc/rackspace-monitoring-agent.cfg ]; then
-              service rackspace-monitoring-agent stop || :
-              service rackspace-monitoring-agent start || :
+              /etc/init.d/rackspace-monitoring-agent stop || :
+              /etc/init.d/rackspace-monitoring-agent start || :
          fi
         ;;
     *)


### PR DESCRIPTION
service is broken on debian and if it detects an upstart config
file it will try to use upstart which isn't installed on debian.

Since the init script now calls out to upstart lets just use
the init script for auto restarts.
