### PR TITLE
monitoring: tests: skip test_upgrades

### DIFF
--- a/agents/monitoring/tests/net/init.lua
+++ b/agents/monitoring/tests/net/init.lua
@@ -73,6 +73,9 @@ end
 exports['test_upgrades'] = function(test, asserts)
   local options, client, endpoints
 
+  test.skip("Skip upgrades test until it is reliable")
+  return nil
+
   -- Override the default download path
   consts.DEFAULT_DOWNLOAD_PATH = path.join('.', 'tmp')
 


### PR DESCRIPTION
skip this step until we fix the crasher
