### PR TITLE
monitoring: client: disable upgrade polling

### DIFF
--- a/agents/monitoring/default/client/connection_statemachine.lua
+++ b/agents/monitoring/default/client/connection_statemachine.lua
@@ -71,7 +71,8 @@ function ConnectionStateMachine:_reactHandshake(client, state, msg)
   end
   self._connectionStream:promoteClient(client)
   self._connectionStream:clearDelay(client.datacenter)
-  self._connectionStream:getUpgrade():start()
+  -- TODO: Re-enable when we fix the crasher
+  -- self._connectionStream:getUpgrade():start()
   client:startHeartbeatInterval()
   return self.states.TimeSync
 end
@@ -105,7 +106,8 @@ function ConnectionStateMachine:_reactDeactivate(client, state, msg)
   end
   client:clearHeartbeatInterval()
   if self._connectionStream:getClient() == nil then
-    self._connectionStream:getUpgrade():stop()
+    -- TODO: Re-enable when we fix the crasher
+    -- self._connectionStream:getUpgrade():stop()
   end
   self:_autoTransition(client, state, msg)
   return self.states.TimeSyncDeactivate

--- a/agents/monitoring/default/client/connection_stream.lua
+++ b/agents/monitoring/default/client/connection_stream.lua
@@ -61,8 +61,9 @@ function ConnectionStream:initialize(id, token, guid, options)
   self._messages = ConnectionMessages:new(self)
   misc.propagateEvents(self._messages, self, _event_names)
 
-  self._upgrade = UpgradePollEmitter:new()
-  self._upgrade:on('upgrade', utils.bind(ConnectionStream._onUpgrade, self))
+  -- TODO: Re-enable upgrade polling once we track down the crasher
+  -- self._upgrade = UpgradePollEmitter:new()
+  -- self._upgrade:on('upgrade', utils.bind(ConnectionStream._onUpgrade, self))
 end
 
 function ConnectionStream:getUpgrade()


### PR DESCRIPTION
upgrade downloads, in testing, has been shown to cause a reproducible
crash. Until we fix this disable upgrade polling.
