### PR TITLE
Remove the Windows Drive from the mkdir parent list

### DIFF
--- a/agents/monitoring/default/util/fs.lua
+++ b/agents/monitoring/default/util/fs.lua
@@ -46,7 +46,7 @@ function mkdirp(lpath, mode, callback)
   if os.type() == "win32" then
     -- Do not try to create a Windows Drive
     if tocreate[1]:match("^[%a]:$") then
-      table.remove(tocreate,1)
+      table.remove(tocreate, 1)
     end
   end
   async.forEachSeries(tocreate, function (dir, callback)


### PR DESCRIPTION
Fix a bug in the util/fs.lua mkdirp function to strip the drive letter so that it never tries to create the drive.
