### PR TITLE
Change the net test, test_reconnects, to skip itself

### DIFF
--- a/agents/monitoring/tests/net/init.lua
+++ b/agents/monitoring/tests/net/init.lua
@@ -9,11 +9,17 @@ local constants = require('constants')
 local consts = require('../../default/util/constants')
 local Endpoint = require('../../default/endpoint').Endpoint
 local path = require('path')
+local os = require('os')
 
 local exports = {}
 local child
 
 exports['test_reconnects'] = function(test, asserts)
+
+  if os.type() == "win32" then
+    test.skip("Skip test_reconnects until a suitable SIGUSR1 replacement is used in runner.py")
+    return nil
+  end
 
   local options = {
     datacenter = 'test',


### PR DESCRIPTION
Change the net test, test_reconnects, to skip itself as it uses
a test_server_fixture_blocking that calls a SIGUSR1.  Windows can't
SIGUSR1, see: http://docs.python.org/2/library/signal.html#signal.signal
We'll need a Windows specific way of emulating the SIGUSR1 functionality
in the Agent.
