### PR TITLE
Added a --crash flag to the agent.

### DIFF
--- a/agents/monitoring/default/init.lua
+++ b/agents/monitoring/default/init.lua
@@ -22,6 +22,10 @@ local function main(argv)
   argv = argv and argv or {}
   local options = {}
 
+  if argv.crash then
+    return virgo.force_crash()
+  end
+
   if argv.s then
     options.stateDirectory = argv.s
   end

--- a/agents/monitoring/monitoring.c
+++ b/agents/monitoring/monitoring.c
@@ -66,6 +66,7 @@ show_help()
          "  -i, --insecure        Use insecure SSL CA cert (for testing/debugging).\n"
          "  -D, --detach          Detach the process and run the agent in the background.\n"
          "  --production          Write debug information to disk when the agent crahes.\n"
+         "  --crash               Crash the agent.\n"
          "\n"
          "Documentation can be found at http://monitoring.api.rackspacecloud.com/\n");
   fflush(stdout);


### PR DESCRIPTION
The original goal was to do this on sigusr2, but installing that handler caused problems with crash dumps.  I'm not sure where the real problem is (luvit/breakpad).  

This will allow us to test crashes in official builds and the whole crash dump pipeline.  I'm not really happy with were this code lives, but it has to run after we have fully initialized our lua/luvit stack.
