### PR TITLE
[RFC] If a custom plugin check exists with non-zero exit code, but a status message is provided, use it instead of using the default one

### DIFF
--- a/agents/monitoring/tests/check/init.lua
+++ b/agents/monitoring/tests/check/init.lua
@@ -303,8 +303,8 @@ exports['test_custom_plugin_timeout'] = function(test, asserts)
 end
 
 exports['test_custom_plugin_file_not_executable'] = function(test, asserts)
-  if os.type() == "win32" then
-    test.skip("Unsupported Platform for custom plugins")
+  if os.type() == 'win32' then
+    test.skip('Unsupported Platform for custom plugins')
     return
   end
 
@@ -317,6 +317,26 @@ exports['test_custom_plugin_file_not_executable'] = function(test, asserts)
   check:run(function(result)
     asserts.ok(result ~= nil)
     asserts.equals(result:getStatus(), 'Plugin exited with non-zero status code (code=127)')
+    asserts.equals(result:getState(), 'unavailable')
+    test.done()
+  end)
+end
+
+exports['test_custom_plugin_non_zero_exit_code_with_status'] = function(test, asserts)
+  if os.type() == 'win32' then
+    test.skip('Unsupported Platform for custom plugins')
+    return
+  end
+
+  constants.DEFAULT_CUSTOM_PLUGINS_PATH = path.join(process.cwd(),
+                      '/agents/monitoring/tests/fixtures/custom_plugins')
+
+  local check = PluginCheck:new({id='foo', period=30,
+                                 details={file='non_zero_with_status.sh'}})
+  asserts.ok(check._lastResult == nil)
+  check:run(function(result)
+    asserts.ok(result ~= nil)
+    asserts.equals(result:getStatus(), 'ponies > unicorns')
     asserts.equals(result:getState(), 'unavailable')
     test.done()
   end)

--- a/agents/monitoring/tests/fixtures/custom_plugins/non_zero_with_status.sh
+++ b/agents/monitoring/tests/fixtures/custom_plugins/non_zero_with_status.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "status ponies > unicorns"
+exit 100


### PR DESCRIPTION
Currently if a plugin exists with non-zero exit code, but a status message is provided we discard the provided message and override it with the default non-zero exit status message (e.g. `Plugin exited with non-zero status code (code=100)`).

I think that's not OK, because I imagine a lot of times people will intentionally exit with non-zero status code and provide a status message which will contain a reason for exiting with non-zero.

Open questions:
- Do other people agree that the pattern I described above is a good one and we should support it? If not we should talk about the alternatives.
- Should we add `exit_code` as a special metric to the check in case check exists with non-zero status code. 

Note: Adding this metric currently doesn't make a lot of sense anyway, because this metric is inaccessible. Currently in the CEP we have a default if statement which short circuits if `state != available`. It's just something to think about.

Note: To reduce noise, please constrain yourself from actually commenting on the code style / etc. until we agree on a solution. I just provided it a a prototype / reference implementation so it makes it easier to talk about.
