### PR TITLE
Add crash version to dump.

### DIFF
--- a/lib/virgo.gyp
+++ b/lib/virgo.gyp
@@ -46,6 +46,7 @@
         'VIRGO_OS="<(OS)"',
         'VIRGO_PLATFORM="<!(python ../tools/virgo_platform.py)"',
         'VIRGO_VERSION="<!(git --git-dir ../.git rev-parse HEAD)"',
+        'VERSION_FULL="<!(python tools/version.py --sep=.)"',
       ],
 
       'sources': [


### PR DESCRIPTION
Dumps should have a version.  The agent that reports the dump is not necessarily the version that died.  I tried to use dependent settings in gyp to avoid duplication, but couldn't get it to work :-/
