### PR TITLE
Every metric except 'files' is in KB.

### DIFF
--- a/agents/monitoring/default/check/filesystem.lua
+++ b/agents/monitoring/default/check/filesystem.lua
@@ -32,9 +32,9 @@ local METRICS = {
 
 local UNITS = {
   total = 'kilobytes',
-  free = 'bytes',
-  used = 'bytes',
-  avail = 'bytes'
+  free = 'kilobytes',
+  used = 'kilobytes',
+  avail = 'kilobytes'
 }
 
 function FileSystemCheck:initialize(params)


### PR DESCRIPTION
```
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/md2        691G  6.0G  650G   1% /
udev             12G  4.0K   12G   1% /dev
tmpfs           4.8G  312K  4.8G   1% /run
none            5.0M     0  5.0M   0% /run/lock
none             12G     0   12G   0% /run/shm
cgroup           12G     0   12G   0% /sys/fs/cgroup
/dev/md1        496M   84M  387M  18% /boot
```

test check output:

```
free_files
45520053 (type: l) 
total
724198344 (type: l) 
avail
681510324 (type: l) 
free
718007812 (type: l) 
files
45629440 (type: l) 
used
6190532 (type: l) 
```
