### PR TITLE
Use the ./configure --debug flag to determine the build target for Windows

### DIFF
--- a/tools/win_build.bat
+++ b/tools/win_build.bat
@@ -1,2 +1,4 @@
+if "%1" == "" set BUILD=Debug
+if NOT "%1" == "" set BUILD=%1
 call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
-devenv.com /build Debug monitoring-agent.sln /project monitoring-agent.vcxproj
+devenv.com /build %BUILD% monitoring-agent.sln /project monitoring-agent.vcxproj

--- a/tools/win_pkg.bat
+++ b/tools/win_pkg.bat
@@ -1,2 +1,4 @@
+if "%1" == "" set BUILD=Release
+if NOT "%1" == "" set BUILD=%1
 call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
-devenv.com /build Release monitoring-agent.sln /project rackspace-monitoring-agent.msi.vcxproj
+devenv.com /build %BUILD% monitoring-agent.sln /project rackspace-monitoring-agent.msi.vcxproj


### PR DESCRIPTION
Use the ./configure --debug flag to determine the build target for Windows builds to build the code and packages either Release and Debug.
