### PR TITLE
Pass -l option to rackspace-monitoring-agent in the upstart file

### DIFF
--- a/pkg/monitoring/debian/package.upstart
+++ b/pkg/monitoring/debian/package.upstart
@@ -4,4 +4,4 @@ start on stopped rc RUNLEVEL=[2345]
 stop on runlevel [!2345]
 
 respawn
-exec rackspace-monitoring-agent --production >> /var/log/rackspace-monitoring-agent.log 2>&1
+exec rackspace-monitoring-agent --production -l /var/log/rackspace-monitoring-agent.log 2>&1


### PR DESCRIPTION
Currently we use redirect instead of using Virgo logging facility which means sending `SIGHUP` to the process won't cause log file to be reopened and log rotation won't work correctly.

We already use -l flag in the init script (https://github.com/racker/virgo/blob/master/pkg/monitoring/debian/package.init#L30) so I think it should be fine to use it here as well.

I did check if there is maybe a specific reason why we use redirect instead of virgo logging facility, but I couldn't find anything in the git history.
