### PR TITLE
Add non-standard units to check metrics.

### DIFF
--- a/agents/monitoring/default/check/apache.lua
+++ b/agents/monitoring/default/check/apache.lua
@@ -92,7 +92,8 @@ function ApacheCheck:_parseLine(line, checkResult)
   local metrics = {
     ['Total_Accesses'] = {
       ['type'] = 'gauge',
-      ['name'] = 'total_accesses'
+      ['name'] = 'total_accesses',
+      ['unit'] = 'accesses'
     },
     ['Total_kBytes'] = {
       ['type'] = 'uint64',
@@ -116,11 +117,13 @@ function ApacheCheck:_parseLine(line, checkResult)
     },
     ['BusyWorkers'] = {
       ['type'] = 'uint64',
-      ['name'] = 'busy_workers'
+      ['name'] = 'busy_workers',
+      ['unit'] = 'workers'
     },
     ['IdleWorkers'] = {
       ['type'] = 'uint64',
-      ['name'] = 'idle_workers'
+      ['name'] = 'idle_workers',
+      ['unit'] = 'workers'
     },
     ['CPULoad'] = {
       ['type'] = 'double',
@@ -129,7 +132,8 @@ function ApacheCheck:_parseLine(line, checkResult)
     },
     ['ReqPerSec'] = {
       ['type'] = 'double',
-      ['name'] = 'requests_per_second'
+      ['name'] = 'requests_per_second',
+      ['unit'] = 'requests'
     }
   }
 

--- a/agents/monitoring/default/check/disk.lua
+++ b/agents/monitoring/default/check/disk.lua
@@ -53,13 +53,16 @@ function DiskCheck:run(callback)
   local checkResult = CheckResult:new(self, {})
   local name, usage
   local units = {
+    reads = 'reads',
+    writes = 'writes',
     read_bytes = 'bytes',
     write_bytes = 'bytes',
     rtime = 'milliseconds',
     wtime = 'milliseconds',
     qtime = 'milliseconds',
     time = 'milliseconds',
-    service_time = 'milliseconds'
+    service_time = 'milliseconds',
+    queue = 'seconds'
   }
   local metrics = {
     'reads',

--- a/agents/monitoring/default/check/filesystem.lua
+++ b/agents/monitoring/default/check/filesystem.lua
@@ -34,7 +34,9 @@ local UNITS = {
   total = 'kilobytes',
   free = 'kilobytes',
   used = 'kilobytes',
-  avail = 'kilobytes'
+  avail = 'kilobytes',
+  files = 'files',
+  free_files = 'free_files'
 }
 
 function FileSystemCheck:initialize(params)

--- a/agents/monitoring/default/check/mysql.lua
+++ b/agents/monitoring/default/check/mysql.lua
@@ -97,37 +97,37 @@ end
 
 -- List of MySQL Stats that we export, along with their metric type.
 local stat_map = {
-  Aborted_clients = { type = 'uint64', alias = 'core.aborted_clients' },
-  Connections = { type = 'gauge', alias = 'core.connections' },
+  Aborted_clients = { type = 'uint64', alias = 'core.aborted_clients', unit = 'clients' },
+  Connections = { type = 'gauge', alias = 'core.connections', unit = 'connections'},
 
-  Innodb_buffer_pool_pages_dirty = { type = 'uint64', alias = 'innodb.buffer_pool_pages_dirty' },
-  Innodb_buffer_pool_pages_free = { type = 'uint64', alias = 'innodb.buffer_pool_pages_free'},
-  Innodb_buffer_pool_pages_flushed = { type = 'uint64', alias = 'innodb.buffer_pool_pages_flushed'},
-  Innodb_buffer_pool_pages_total = { type = 'uint64', alias = 'innodb.buffer_pool_pages_total'},
+  Innodb_buffer_pool_pages_dirty = { type = 'uint64', alias = 'innodb.buffer_pool_pages_dirty', unit = 'pages' },
+  Innodb_buffer_pool_pages_free = { type = 'uint64', alias = 'innodb.buffer_pool_pages_free', unit = 'pages'},
+  Innodb_buffer_pool_pages_flushed = { type = 'uint64', alias = 'innodb.buffer_pool_pages_flushed', unit = 'pages'},
+  Innodb_buffer_pool_pages_total = { type = 'uint64', alias = 'innodb.buffer_pool_pages_total', unit = 'pages'},
   Innodb_row_lock_time = { type = 'uint64', alias = 'innodb.row_lock_time', unit = 'milliseconds'},
   Innodb_row_lock_time_avg = { type = 'uint64', alias = 'innodb.row_lock_time_avg', unit = 'milliseconds'},
   Innodb_row_lock_time_max = { type = 'uint64', alias = 'innodb.row_lock_time_max', unit = 'milliseconds'},
-  Innodb_rows_deleted = { type = 'gauge', alias = 'innodb.rows_deleted'},
-  Innodb_rows_inserted = { type = 'gauge', alias = 'innodb.rows_inserted'},
-  Innodb_rows_read = { type = 'gauge', alias = 'innodb.rows_read'},
-  Innodb_rows_updated = { type = 'gauge', alias = 'innodb.rows_updated'},
+  Innodb_rows_deleted = { type = 'gauge', alias = 'innodb.rows_deleted', unit = 'rows'},
+  Innodb_rows_inserted = { type = 'gauge', alias = 'innodb.rows_inserted', unit = 'rows'},
+  Innodb_rows_read = { type = 'gauge', alias = 'innodb.rows_read', unit = 'rows'},
+  Innodb_rows_updated = { type = 'gauge', alias = 'innodb.rows_updated', unit = 'rows'},
 
-  Queries = { type = 'gauge', alias = 'core.queries'},
+  Queries = { type = 'gauge', alias = 'core.queries', unit = 'queries'},
 
-  Threads_connected = { type = 'uint64', alias = 'threads.connected'},
-  Threads_created = { type = 'uint64', alias = 'threads.created'},
-  Threads_running = { type = 'uint64', alias = 'threads.running'},
+  Threads_connected = { type = 'uint64', alias = 'threads.connected', unit = 'threads'},
+  Threads_created = { type = 'uint64', alias = 'threads.created', unit = 'threads'},
+  Threads_running = { type = 'uint64', alias = 'threads.running', unit = 'threads'},
 
   Uptime = { type = 'uint64', alias = 'core.uptime', unit = 'seconds'},
 
-  Qcache_free_blocks = { type = 'uint64', alias = 'qcache.free_blocks'},
+  Qcache_free_blocks = { type = 'uint64', alias = 'qcache.free_blocks', unit = 'blocks'},
   Qcache_free_memory = { type = 'uint64', alias = 'qcache.free_memory', unit = 'bytes'},
-  Qcache_hits = { type = 'gauge', alias = 'qcache.hits'},
-  Qcache_inserts  = { type = 'gauge', alias = 'qcache.inserts'},
-  Qcache_lowmem_prunes  = { type = 'gauge', alias = 'qcache.lowmem_prunes'},
-  Qcache_not_cached = { type = 'gauge', alias = 'qcache.not_cached'},
-  Qcache_queries_in_cache = { type = 'uint64', alias = 'qcache.queries_in_cache'},
-  Qcache_total_blocks = { type = 'uint64', alias = 'qcache.total_blocks'},
+  Qcache_hits = { type = 'gauge', alias = 'qcache.hits', unit = 'hits'},
+  Qcache_inserts  = { type = 'gauge', alias = 'qcache.inserts', unit = 'inserts'},
+  Qcache_lowmem_prunes  = { type = 'gauge', alias = 'qcache.lowmem_prunes', unit = 'prunes'},
+  Qcache_not_cached = { type = 'gauge', alias = 'qcache.not_cached', unit = 'queries'},
+  Qcache_queries_in_cache = { type = 'uint64', alias = 'qcache.queries_in_cache', unit = 'queries'},
+  Qcache_total_blocks = { type = 'uint64', alias = 'qcache.total_blocks', unit = 'blocks'},
 }
 
 function MySQLCheck:_runCheckInChild(callback)

--- a/agents/monitoring/default/check/network.lua
+++ b/agents/monitoring/default/check/network.lua
@@ -19,7 +19,18 @@ local CheckResult = require('./base').CheckResult
 local table = require('table')
 local units = {
   rx_bytes = 'bytes',
-  tx_bytes = 'bytes'
+  rx_dropped = 'packets',
+  rx_errors = 'errors',
+  rx_frame = 'frames',
+  rx_overruns = 'overruns',
+  rx_packets = 'packets',
+  tx_bytes = 'bytes',
+  tx_carrier = 'errors',
+  tx_collisions = 'collisions',
+  tx_dropped = 'packets',
+  tx_errors = 'errors',
+  tx_overruns = 'overruns',
+  tx_packets = 'packets'
 }
 
 local NetworkCheck = BaseCheck:extend()


### PR DESCRIPTION
This should add units to all metrics which are currently reporting a nil or unknown unit type.
