### PR TITLE
Generate monitoring-agent VERSION_FULL differently on Windows

### DIFF
--- a/monitoring-agent.gyp
+++ b/monitoring-agent.gyp
@@ -37,7 +37,13 @@
       'agents/monitoring/crash',
       'agents/monitoring/tests',
     ],
+
     'VERSION_FULL': '<!(python tools/version.py)',
+
+    'conditions': [
+        [ 'OS=="win"', { 'VERSION_FULL': '<!(python tools/version.py -s .)', }, ],
+    ],
+
     'VERSION_MAJOR': '<!(python tools/version.py major)',
     'VERSION_MINOR': '<!(python tools/version.py minor)',
     'VERSION_PATCH': '<!(python tools/version.py patch)',


### PR DESCRIPTION
Generate monitoring-agent VERSION_FULL on Windows as x.x.x.x as opposed to x.x.x-x as on other platforms.

This allows the packaging to work.
