### PR TITLE
Fix child process spawning for virgo self upgrades

### DIFF
--- a/agents/monitoring/default/check/base.lua
+++ b/agents/monitoring/default/check/base.lua
@@ -464,7 +464,7 @@ end
 
 function SubProcCheck:run(callback)
   local args = {
-    '-n',
+    '-o',
     '-e',
     'default/check_runner',
     '--zip',

--- a/agents/monitoring/runner.py
+++ b/agents/monitoring/runner.py
@@ -14,7 +14,7 @@ def test_cmd(additional=""):
     state_config = os.path.join(paths.root, 'contrib')
     monitoring_config = os.path.join(paths.root, 'agents', 'monitoring', 'tests', 'fixtures', 'monitoring-agent-localhost.cfg')
     zip_file = "monitoring.zip"
-    cmd = '%s -n -z %s -c %s -s %s %s' % (paths.agent, zip_file, monitoring_config, state_config, additional)
+    cmd = '%s -o -z %s -c %s -s %s %s' % (paths.agent, zip_file, monitoring_config, state_config, additional)
     print cmd
     return cmd
 

--- a/lib/virgo_exec.c
+++ b/lib/virgo_exec.c
@@ -55,7 +55,7 @@ copy_args(virgo_t *v, const char *bundle_path) {
     args[index++] = strdup(quoted_bundle);
   }
 #endif
-  args[index++] = strdup("-n");
+  args[index++] = strdup("-o");
   args[index++] = NULL;
 
   return args;
@@ -70,8 +70,11 @@ virgo__exec(virgo_t *v, char *exe_path, const char *bundle_path) {
 
   args[0] = exe_path;
   rc = execve(exe_path, args, environ);
-  if (rc < 0) { /* on success, does not execute */
+  if (rc < 0) { /* on success, does not execute, unless running windows */
     return virgo_error_createf(VIRGO_ENOFILE, "execve failed errno=%i", errno);
+  } else {
+    /* running windows, exit quick! */
+    exit(0);
   }
 
   return VIRGO_SUCCESS;


### PR DESCRIPTION
- in several places the obsolete -n was used instead of the current -o.
- have virgo exit on execve success (Unix never reaches there as the running process is overwritten, emulate that on windows by exiting the current (parent) process) 
