### PR TITLE
Use UUIDs for Agent IDs, improve binding procedure

### DIFF
--- a/agents/monitoring/default/setup.lua
+++ b/agents/monitoring/default/setup.lua
@@ -397,7 +397,6 @@ function Setup:run(callback)
 
           -- This server matches exactly 1 entity and it has a URI. Just use it.
           if #localEntities == 1 and localEntities[1].uri ~= nil then
-            self:_out('')
             self:_out(fmt('This server matches entity %s, binding to it...', localEntities[1].id))
             client.entities.update(localEntities[1].id, { agent_id = self._agentId }, callback)
             return


### PR DESCRIPTION
This PR:
1. Uses a random UUID as the agent ID to avoid issues with hostnames
2. Skips asking the user to select an entity if there is exactly one entity that seems like a match, and it has a URI
3. Allows the agent to be re-associated with a different entity using a new agent ID

This needs more manual testing (I wrote it without internet access, which makes --setup tough to test), I'll work on that when I get a chance.
