### PR TITLE
Windows Operating System Performance Data Check

### DIFF
--- a/agents/monitoring/default/check/init.lua
+++ b/agents/monitoring/default/check/init.lua
@@ -28,6 +28,7 @@ local RedisCheck = require('./redis').RedisCheck
 local NullCheck = require('./null').NullCheck
 local LoadAverageCheck = require('./load_average').LoadAverageCheck
 local PluginCheck = require('./plugin').PluginCheck
+local WindowsPerfOSCheck = require('./windows').WindowsPerfOSCheck
 
 local Error = require('core').Error
 
@@ -65,6 +66,8 @@ function create(checkData)
     return RedisCheck:new(obj)
   elseif checkType == 'agent.null' then
     return NullCheck:new(obj)
+  elseif checkType == 'agent.windows_perfos' then
+    return WindowsPerfOSCheck:new(obj)
   else
     return nil
   end
@@ -121,6 +124,7 @@ exports.RedisCheck = RedisCheck
 exports.LoadAverageCheck = LoadAverageCheck
 exports.ApacheCheck = ApacheCheck
 exports.NullCheck = NullCheck
+exports.WindowsPerfOSCheck = WindowsPerfOSCheck
 
 exports.create = create
 exports.test = test

--- a/agents/monitoring/default/check/windows.lua
+++ b/agents/monitoring/default/check/windows.lua
@@ -1,0 +1,138 @@
+--[[
+Copyright 2013 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local BaseCheck = require('./base').BaseCheck
+local CheckResult = require('./base').CheckResult
+local spawn = require('childprocess').spawn
+local fireOnce = require('../util/misc').fireOnce
+local parseCSVLine = require('../util/misc').parseCSVLine
+local table = require('table')
+local string = require('string')
+local os = require('os')
+
+local function lines(str)
+  local t = {}
+  local function helper(line)
+    table.insert(t, line)
+    return ""
+  end
+  helper((str:gsub("(.-)\r?\n", helper)))
+  return t
+end
+
+local WindowsPerfOSCheck = BaseCheck:extend()
+
+function WindowsPerfOSCheck:initialize(params)
+  BaseCheck.initialize(self, 'agent.windows_perfos', params)
+end
+
+--[[
+# So this should create a Perf.csv file in the temp directory
+powershell "(get-wmiobject Win32_PerfFormattedData_PerfOS_System).Properties | Select Name, Value, Type | ConvertTo-Csv"
+--]]
+
+local wmi_type_map = {
+  uint8='uint32',
+  uint16='uint32',
+  uint32='uint32',
+  uint64='uint64',
+  sint8='int32',
+  sint16='int32',
+  sint32='int32',
+  sint64='int64',
+  real32='double',
+  real64='double'
+  }
+local PerfOS_System_Properties_Ignore = {
+  Caption=true,
+  Description=true,
+  Name=true,
+  Frequency_Object=true,
+  Frequency_PerfTime=true,
+  Frequency_Sys100NS=true,
+  Timestamp_Object=true,
+  Timestamp_PerfTime=true,
+  Timestamp_Sys100NS=true
+  }
+
+function WindowsPerfOSCheck:run(callback)
+  -- Set up
+  local callback = fireOnce(callback)
+  local checkResult = CheckResult:new(self, {})
+  local block_data = ''
+
+  if os.type() ~= 'win32' then
+    checkResult:setStatus("err agent.windows_perfos available only on Windows platforms")
+
+    -- Return Result
+    self._lastResult = checkResult
+    callback(checkResult)
+    return
+  end
+
+  -- Perform Check
+  local options = {}
+  local child = spawn('powershell.exe', {'(get-wmiobject Win32_PerfFormattedData_PerfOS_System).Properties | Select Name, Value, Type | ConvertTo-Csv'}, options)
+  child.stdout:on('data', function(chunk)
+    -- aggregate the output
+    block_data = block_data .. chunk
+  end)
+  child:on('exit', function(exit_code)
+    -- Build Dataset from Block Data
+    local data_lines = lines(block_data)
+    local count = 0
+    local headings = {}
+    for x, line in pairs(data_lines) do
+      if string.sub(line,1,1) ~= '#' then
+        count = count + 1
+        if count == 1 then
+          local temp = parseCSVLine(line)
+          local i = 0
+          -- Map headings to indexes
+          for x, heading in pairs(temp) do
+            i = i + 1
+            headings[heading] = i
+          end
+        else
+          -- Parse Data, coverting to numbers when needed
+          local entry = parseCSVLine(line)
+          if entry[headings['Name']] ~= nil and PerfOS_System_Properties_Ignore[entry[headings['Name']]] ~= true then
+            local type = 'string'
+            if entry[headings['Type']] ~= nil and wmi_type_map[string.lower(entry[headings['Type']])] ~=nil then
+               type = wmi_type_map[string.lower(entry[headings['Type']])]
+            end
+            checkResult:addMetric(entry[headings['Name']], nil, type, entry[headings['Value']], '')
+          end
+        end
+      end
+    end
+
+    -- Return Result
+    self._lastResult = checkResult
+    callback(checkResult)
+  end)
+  child:on('error', function(err)
+    checkResult:setStatus("err " .. err)
+
+    -- Return Result
+    self._lastResult = checkResult
+    callback(checkResult)
+  end)
+end
+
+local exports = {}
+exports.WindowsPerfOSCheck = WindowsPerfOSCheck
+return exports

--- a/agents/monitoring/default/util/misc.lua
+++ b/agents/monitoring/default/util/misc.lua
@@ -275,6 +275,47 @@ function copyFile(fromFile, toFile, callback)
 end
 
 
+function parseCSVLine (line,sep) 
+  local res = {}
+  local pos = 1
+  sep = sep or ','
+  while true do 
+    local c = string.sub(line,pos,pos)
+    if (c == "") then break end
+    if (c == '"') then
+      -- quoted value (ignore separator within)
+      local txt = ""
+      repeat
+        local startp,endp = string.find(line,'^%b""',pos)
+        txt = txt..string.sub(line,startp+1,endp-1)
+        pos = endp + 1
+        c = string.sub(line,pos,pos) 
+        if (c == '"') then txt = txt..'"' end 
+        -- check first char AFTER quoted string, if it is another
+        -- quoted string without separator, then append it
+        -- this is the way to "escape" the quote char in a quote. example:
+        --   value1,"blub""blip""boing",value3  will result in blub"blip"boing  for the middle
+      until (c ~= '"')
+      table.insert(res,txt)
+      assert(c == sep or c == "")
+      pos = pos + 1
+    else	
+      -- no quotes used, just look for the first separator
+      local startp,endp = string.find(line,sep,pos)
+      if (startp) then 
+        table.insert(res,string.sub(line,pos,startp-1))
+        pos = endp + 1
+      else
+        -- no separator found -> use rest of string and terminate
+        table.insert(res,string.sub(line,pos))
+        break
+      end 
+    end
+  end
+  return res
+end
+
+
 --[[ Exports ]]--
 local exports = {}
 exports.copyFile = copyFile
@@ -291,4 +332,5 @@ exports.fireOnce = fireOnce
 exports.nCallbacks = nCallbacks
 exports.compareVersions = compareVersions
 exports.propagateEvents = propagateEvents
+exports.parseCSVLine = parseCSVLine
 return exports

--- a/agents/monitoring/tests/check/init.lua
+++ b/agents/monitoring/tests/check/init.lua
@@ -39,12 +39,15 @@ local ApacheTests = require('./apache')
 local FileSystemTests = require('./filesystem')
 local LoadTests = require('./load_average')
 local RedisTests = require('./redis')
+local WindowsTests = require('./windows')
 
 local exports = merge(MySQLTests, {})
 exports = merge(exports, ApacheTests)
 exports = merge(exports, FileSystemTests)
 exports = merge(exports, LoadTests)
 exports = merge(exports, RedisTests)
+exports = merge(exports, WindowsTests)
+
 
 exports['test_base_check'] = function(test, asserts)
   local check = BaseCheck:new('test', {id='foo', period=30})

--- a/agents/monitoring/tests/check/windows.lua
+++ b/agents/monitoring/tests/check/windows.lua
@@ -1,0 +1,29 @@
+local math = require('math')
+local os = require('os')
+
+local WindowsPerfOSCheck = require('monitoring/default/check/windows').WindowsPerfOSCheck
+
+local exports = {}
+
+exports['test_windowsperfos_check'] = function(test, asserts)
+  local check = WindowsPerfOSCheck:new({id='foo', period=30})
+  asserts.ok(check._lastResult == nil)
+  check:run(function(result)
+    asserts.ok(result ~= nil)
+    asserts.ok(check._lastResult ~= nil)
+
+    if os.type() == 'win32' then
+      asserts.ok(result:getStatus() == 'success')
+      asserts.ok(#check._lastResult:serialize() > 0)
+      local metrics = result:getMetrics()['none']
+      asserts.ok(metrics['Processes']['t'] == 'uint32')
+      -- Values always become strings internally
+      asserts.ok(tonumber(metrics['Processes']['v']) > 0)
+    else
+      asserts.ok(result:getStatus() ~= 'success')
+    end
+    test.done()
+  end)
+end
+
+return exports


### PR DESCRIPTION
- Exposes the Win32_PerfFormattedData_PerfOS_System via the PowerShell
- Converts the Win32_PerfFormattedData_PerfOS_System data into a CSV
- Uses the CSV to populate the check metrics
- Expose the WMI data-types in the CSV and map them to virgo types
- Write a test case to try it on Windows, and error according on other OSes
