### PR TITLE
(seemingly) fixed reversed logic in init.lua that makes -i non-functioning

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -70,7 +70,7 @@ function Entry.run()
 
   if argv.args.i then
     options.tls = {
-      rejectUnauthorized = true,
+      rejectUnauthorized = false,
       ca = require('./certs').caCertsDebug
     }
   end


### PR DESCRIPTION
assuming -i or --insecure means to accept self-signed CA
