### PR TITLE
WIP fix inconsistency in types of IDs

### DIFF
--- a/protocol/messages.lua
+++ b/protocol/messages.lua
@@ -19,7 +19,7 @@ local Object = require('core').Object
 --[[ Message ]]--
 local Message = Object:extend()
 function Message:initialize()
-  self.id = 1
+  self.id = '1'
   self.target = ''
   self.source = ''
 end
@@ -57,7 +57,7 @@ function Request:initialize()
 end
 
 function Request:serialize(msgId)
-  self.id = msgId
+  self.id = tostring(msgId)
 
   return {
     v = '1',


### PR DESCRIPTION
`message.id` (`string`) defined in `protocol/message.lua` is inconsistent with `AgentProtocolClient._msgid` (`int`) defined in `protocol/connection.lua`.
This results in different types of messages sent from agents to
endpoint, which is probably not a big problem in weakly typed languages
but will cause problems in typed languages like Go. This commit changes
`message.id` from `string` to `int` in `protocol/message.lua`, which looks more reasonable to me given the
context if IDs, but there are other places where string is used for IDs,
e.g., `check/base.lua`, line 53, `tostring()` is explictly used to produce
a string for `self.id`. What is desired type for IDs?
