### PR TITLE
There's reversed logic in comparing versions during upgrade

### DIFF
--- a/client/connection_stream.lua
+++ b/client/connection_stream.lua
@@ -103,7 +103,7 @@ function ConnectionStream:_onUpgrade()
       client:log(logging.INFO, fmt('(upgrade) -> Upgrades Disabled'))
       return
     end
-    if misc.compareVersions(version, bundleVersion) < 0 then
+    if misc.compareVersions(version, bundleVersion) > 0 then
       client:log(logging.INFO, fmt('(upgrade) -> Performing upgrade to %s', version))
       self._messages:getUpgrade(version, client, function(err)
         if err then


### PR DESCRIPTION
The issue would cause the agent only upgrade when the remote repo package version is smaller (older) than current bundle version (which is downgrade only actually).

It seems that months ago, the logic was right, then was reversed somehow during a lot of refactoring. It's possible that the change was "motivated" by some other issues in our code, so it's probably better not to simply merge this for now.

In addition, @robert-chiniquy suggests it would be nice to have a test case that ensures that when remote version is newer than local bundle version, upgrading will happen. There indeed is a test for this, which is in tests/net. But it was set to be skipped "until it is reliable". I tried to enable it again but couldn't fix upgrading files path problem.
