### PR TITLE
Add monitoring_snet_region

### DIFF
--- a/util/constants.lua
+++ b/util/constants.lua
@@ -40,13 +40,36 @@ if misc.isStaging() then
     '_monitoringagent._tcp.ord1.stage.monitoring.api.rackspacecloud.com',
     '_monitoringagent._tcp.lon3.stage.monitoring.api.rackspacecloud.com'
   }
+
+  exports.SNET_MONITORING_TEMPLATE_SRV_QUERIES = {
+      '_monitoringagent._tcp.snet-${region}-region0.stage.monitoring.api.rackspacecloud.com',
+      '_monitoringagent._tcp.snet-${region}-region1.stage.monitoring.api.rackspacecloud.com',
+      '_monitoringagent._tcp.snet-${region}-region2.stage.monitoring.api.rackspacecloud.com'
+  }
 else
   exports.DEFAULT_MONITORING_SRV_QUERIES = {
     '_monitoringagent._tcp.dfw1.prod.monitoring.api.rackspacecloud.com',
     '_monitoringagent._tcp.ord1.prod.monitoring.api.rackspacecloud.com',
     '_monitoringagent._tcp.lon3.prod.monitoring.api.rackspacecloud.com'
   }
+
+  exports.SNET_MONITORING_TEMPLATE_SRV_QUERIES = {
+    '_monitoringagent._tcp.snet-${region}-region0.prod.monitoring.api.rackspacecloud.com',
+    '_monitoringagent._tcp.snet-${region}-region1.prod.monitoring.api.rackspacecloud.com',
+    '_monitoringagent._tcp.snet-${region}-region2.prod.monitoring.api.rackspacecloud.com'
+  }
+
 end
+
+exports.VALID_SNET_REGION_NAMES = {
+  'dfw',
+  'ord',
+  'lon',
+  'syd',
+  'hkg',
+  'iad'
+}
+
 
 local PERSISTENT_DIR = virgo_paths.get(virgo_paths.VIRGO_PATH_PERSISTENT_DIR)
 local EXE_DIR = virgo_paths.get(virgo_paths.VIRGO_PATH_EXE_DIR)


### PR DESCRIPTION
- New configuration variable `monitoring_snet_region`
- Hard code a list of valid regions to help detect errors in configuration. (easy to expand or remove later)

Example use:

```
monitoring_snet_region dfw
```

![](http://i.imgur.com/o7x1oEZ.gif)
