### PR TITLE
Last fix to enable all custom plug-in tests on Windows.

### DIFF
--- a/tests/check/init.lua
+++ b/tests/check/init.lua
@@ -80,9 +80,6 @@ end
 local plugin_test = function(name, status, state, optional)
   local optional = optional or {}
   return function(test, asserts)
-    if os.type() == 'win32' then
-      return test.skip('Unsupported Platform for custom plugins')
-    end
     local perms = optional.perms or '0777'
     local period = optional.period or 30
     local details = optional.details or {}
@@ -334,8 +331,14 @@ end
 exports['test_custom_plugin_timeout'] = plugin_test('timeout.py',
   'Plugin didn\'t finish in 0.5 seconds', 'unavailable', {details={timeout=500}})
 
-exports['test_custom_plugin_file_not_executable'] = plugin_test('not_executable.sh',
-  'Plugin exited with non-zero status code (code=127)', 'unavailable', {perms='0444'})
+exports['test_custom_plugin_file_not_executable'] = function(test, asserts)
+  if os.type() == 'win32' then
+    return test.skip('Windows does not have an execute bit, just file associations')
+  else
+    return plugin_test('not_executable.sh',
+      'Plugin exited with non-zero status code (code=127)', 'unavailable', {perms='0444'})
+  end
+end
 
 exports['test_custom_plugin_non_zero_exit_code_with_status'] = plugin_test('non_zero_with_status.sh',
   'ponies > unicorns', 'unavailable')


### PR DESCRIPTION
Last fix to enable all custom plug-in tests on Windows.
- Skips the file executabiltiy test as that permission does not translate to Windows
