### PR TITLE
Prevent agent crash when checking plugin targets

### DIFF
--- a/check/plugin.lua
+++ b/check/plugin.lua
@@ -76,6 +76,10 @@ params.details - Table with the following keys:
 function PluginCheck:initialize(params)
   ChildCheck.initialize(self, params)
 
+  if params.details.file == nil then
+    params.details.file = ''
+  end
+
   local file = path.basename(params.details.file)
   local args = params.details.args and params.details.args or {}
   local timeout = params.details.timeout and params.details.timeout or constants.DEFAULT_PLUGIN_TIMEOUT


### PR DESCRIPTION
The agent currently crashes when hitting /entities/<entity_id>/agent/check_types/agent.plugin/targets due to the reason:

\base\deps\luvit\lib\luvit\path.lua:138: attempt to index local 'filepath' (a nil value).

I believe setting the default file to ' ' will solve for this. 
