### PR TITLE
fix: change the plugin timeout to accommodate slower windows hosts

### DIFF
--- a/tests/check/init.lua
+++ b/tests/check/init.lua
@@ -371,9 +371,8 @@ exports['test_custom_plugin_cmd_arguments'] = plugin_test('plugin_custom_argumen
   end}
 )
 
--- On some Windows platforms this check requires longer to complete
 exports['test_custom_plugin_all_types'] = plugin_test('plugin_1.sh',
-  'Everything is OK', 'available', {details = {timeout = 60*1000}, cb = function(test, asserts, metrics)
+  'Everything is OK', 'available', {cb = function(test, asserts, metrics)
     metrics = metrics['none']
     asserts.dequals(metrics['logged_users'], {t = 'int64', v = '7'})
     asserts.dequals(metrics['active_processes'], {t = 'int64', v = '200'})

--- a/util/constants.lua
+++ b/util/constants.lua
@@ -94,7 +94,7 @@ exports.DEFAULT_PID_FILE_PATH = '/var/run/rackspace-monitoring-agent.pid'
 -- Custom plugins related settings
 
 exports.DEFAULT_CUSTOM_PLUGINS_PATH = path.join(LIBRARY_DIR, 'plugins')
-exports.DEFAULT_PLUGIN_TIMEOUT = 30 * 1000
+exports.DEFAULT_PLUGIN_TIMEOUT = 60 * 1000
 exports.PLUGIN_TYPE_MAP = {string = 'string', int = 'int64', float = 'double', gauge = 'gauge'}
 
 exports.CRASH_REPORT_URL = 'https://monitoring.api.rackspacecloud.com/agent-crash-report'


### PR DESCRIPTION
Integration tests may fail on shorter timeouts.  It seems that when run under a buildbot with admin privileges tests take longer as there may be more to load or scan in order to run the tests.

Reverts and earlier change to make this a global change.
