### PR TITLE
R4R: fixes(auth): use the cloudMonitoring service catalog

### DIFF
--- a/lua_modules/keystone/lib/init.lua
+++ b/lua_modules/keystone/lib/init.lua
@@ -128,7 +128,7 @@ function Client:tenantIdAndToken(callback)
     end
     for i, _ in ipairs(self._serviceCatalog) do
       local item = self._serviceCatalog[i]
-      if item.name == 'cloudServers' or item.name == 'cloudServersLegacy' then
+      if item.name == 'cloudMonitoring' then
         if #item.endpoints == 0 then
           error('Endpoints should be > 0')
         end


### PR DESCRIPTION
customer was seeing a 'forbidden' error on the --setup function of the agent. cloudServers service catalog has been changed to cloudServersOpenstack, but let's use the cloudMonitoring service catalog.
