### PR TITLE
fix(check): Custom plugins stdout

### DIFF
--- a/check/base.lua
+++ b/check/base.lua
@@ -427,14 +427,14 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
     stderrLineEmitter:write(chunk)
   end)
 
-  function waitForIO(callback)
+  local function waitForIO(callback)
     callback = fireOnce(callback)
     child.stdout:on('end', callback)
   end
 
   local code = 0
 
-  function waitForExit(callback)
+  local function waitForExit(callback)
     callback = fireOnce(callback)
     child:on('exit', function(_code)
       code = _code


### PR DESCRIPTION
Stdout may have metric string buffered when we get the exit event. This patch
adds a flag to capture the stdout 'end' event. The process end event adds an
async whilst to wait for stdout to be closed.
