### PR TITLE
Update error message to reflect external config attribute name

### DIFF
--- a/agent.lua
+++ b/agent.lua
@@ -194,7 +194,7 @@ end
 
 function Agent:_preConfig(callback)
   if self._config['token'] == nil then
-    logging.error("'token' is missing from 'config'")
+    logging.error("'monitoring_token' is missing from 'config'")
     process.exit(1)
   end
 


### PR DESCRIPTION
If you try to start the agent and the config is missing `monitoring_token` key, you get the following error:

``` bash
pi@raspberrypi ~/virgo $ /usr/bin/rackspace-monitoring-agent -d
Tue Nov 26 19:25:18 2013 DBG: Using state directory /var/run/rackspace-monitoring-agent/states
Tue Nov 26 19:25:18 2013 ERR: 'token' is missing from 'config'
```

The problem is that `token` is an internal name and as such, the error message is confusing. I've updated the error message to reflect an external setting name.
