### PR TITLE
Fix a plugin error on windows 2012 using spaces in the plugin path

### DIFF
--- a/check/plugin.lua
+++ b/check/plugin.lua
@@ -120,6 +120,7 @@ function PluginCheck:run(callback)
         exePath = assocExe
         -- Force Bypass for this child powershell
         if justExe == "powershell.exe" then
+          table.insert(exeArgs, 1, '-File')
           table.insert(exeArgs, 1, 'Bypass')
           table.insert(exeArgs, 1, '-ExecutionPolicy')
           closeStdin = true -- NEEDED for Powershell 2.0 to exit


### PR DESCRIPTION
this is the simple fix from https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/pull/549

https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/pull/549 is stalled while we sort out the build and test system on other oses where gyp does not support spaces in file names.
