### PR TITLE
fix: setup confd before connecting

### DIFF
--- a/agent.lua
+++ b/agent.lua
@@ -89,10 +89,10 @@ function Agent:start(options)
       misc.writePid(options.pidFile, callback)
     end,
     function(callback)
-      self:connect(callback)
+      self._confd:setup(callback)
     end,
     function(callback)
-      self._confd:setup(callback)
+      self:connect(callback)
     end
   },
   function(err)


### PR DESCRIPTION
This fixes a race condition where the confd files aren't read before the connection finishes and is promoted.
