### PR TITLE
Remove invalid ( at beginning of link

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,7 +74,7 @@ make install
 Setup
 =====
 
-<a href="(http://www.rackspace.com/knowledge_center/article/install-the-cloud-monitoring-agent#Setup">http://www.rackspace.com/knowledge_center/article/install-the-cloud-monitoring-agent#Setup</a>
+<a href="http://www.rackspace.com/knowledge_center/article/install-the-cloud-monitoring-agent#Setup">http://www.rackspace.com/knowledge_center/article/install-the-cloud-monitoring-agent#Setup</a>
 
 License
 =======


### PR DESCRIPTION
This makes the link to the knowledge center work properly.
