### PR TITLE
Add hostinfo plugin to gather info from login.defs

### DIFF
--- a/bundle.list
+++ b/bundle.list
@@ -99,6 +99,7 @@
 ./hostinfo/disk.lua
 ./hostinfo/filesystem.lua
 ./hostinfo/init.lua
+./hostinfo/login.lua
 ./hostinfo/memory.lua
 ./hostinfo/network.lua
 ./hostinfo/nil.lua

--- a/hostinfo/all.lua
+++ b/hostinfo/all.lua
@@ -18,6 +18,7 @@ return {
   require('./cpu'),
   require('./disk'),
   require('./filesystem'),
+  require('./login'),
   require('./memory'),
   require('./network'),
   require('./nil'),

--- a/hostinfo/login.lua
+++ b/hostinfo/login.lua
@@ -1,0 +1,67 @@
+--[[
+Copyright 2014 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+local HostInfo = require('./base').HostInfo
+
+local io = require('io')
+local string = require('string')
+local table = require('table')
+
+--[[ Login ]]--
+local Info = HostInfo:extend()
+function Info:initialize()
+  HostInfo.initialize(self)
+end
+
+function Info:run(callback)
+  local obj = {}
+  local file = io.lines('/etc/login.defs')
+  local append = table.insert
+  
+  obj['login.defs'] = {}
+  
+  -- loop through lines in file
+  for line in file do
+    local iscomment = string.match(line, '^#')
+    local isblank = string.len(line:gsub("%s+", "")) <= 0
+    
+    -- find defs
+    if not iscomment and not isblank then
+      local items = {}
+      local i = 0
+      
+      -- split and assign key/values
+      for item in line:gmatch("%S+") do
+        i = i + 1
+        items[i] = item;
+      end
+      
+      local key = items[1]
+      local value = items[2]
+      
+      -- add def
+      obj['login.defs'][key] = value
+    end
+  end
+  
+  table.insert(self._params, obj)
+  callback()
+end
+
+function Info:getType()
+  return 'LOGIN'
+end
+
+return Info

--- a/hostinfo/login.lua
+++ b/hostinfo/login.lua
@@ -15,7 +15,7 @@ limitations under the License.
 --]]
 local HostInfo = require('./base').HostInfo
 
-local io = require('io')
+local fs = require('fs');
 local string = require('string')
 local table = require('table')
 
@@ -27,37 +27,43 @@ end
 
 function Info:run(callback)
   local obj = {}
-  local file = io.lines('/etc/login.defs')
-  local append = table.insert
-  
+  local filename = "/etc/login.defs"
+    
   obj['login.defs'] = {}
   
-  -- loop through lines in file
-  for line in file do
-    local iscomment = string.match(line, '^#')
-    local isblank = string.len(line:gsub("%s+", "")) <= 0
-    
-    -- find defs
-    if not iscomment and not isblank then
-      local items = {}
-      local i = 0
-      
-      -- split and assign key/values
-      for item in line:gmatch("%S+") do
-        i = i + 1
-        items[i] = item;
-      end
-      
-      local key = items[1]
-      local value = items[2]
-      
-      -- add def
-      obj['login.defs'][key] = value
+  -- open /etc/login.defs
+  fs.readFile(filename, function (err, data)
+    if (err) then
+      return
     end
-  end
-  
-  table.insert(self._params, obj)
-  callback()
+
+    -- split and assign key/values
+    for line in data:gmatch("[^\r\n]+") do
+      local iscomment = string.match(line, '^#')
+      local isblank = string.len(line:gsub("%s+", "")) <= 0
+
+      -- find defs
+      if not iscomment and not isblank then
+        local items = {}
+        local i = 0
+        
+        -- split and assign key/values
+        for item in line:gmatch("%S+") do
+          i = i + 1
+          items[i] = item;
+        end
+        
+        local key = items[1]
+        local value = items[2]
+
+        -- add def
+        obj['login.defs'][key] = value
+      end
+    end
+    
+    table.insert(self._params, obj)
+    callback()
+  end)
 end
 
 function Info:getType()

--- a/hostinfo/login.lua
+++ b/hostinfo/login.lua
@@ -18,6 +18,7 @@ local HostInfo = require('./base').HostInfo
 local fs = require('fs');
 local string = require('string')
 local table = require('table')
+local os = require('os')
 
 --[[ Login ]]--
 local Info = HostInfo:extend()
@@ -26,6 +27,13 @@ function Info:initialize()
 end
 
 function Info:run(callback)
+  
+  if os.type() ~= 'Linux' then
+    self._error = 'Unsupported OS for Login Definitions'
+    callback()
+    return
+  end
+  
   local obj = {}
   local filename = "/etc/login.defs"
     


### PR DESCRIPTION
This plugin can be used to monitor login.defs settings 
to ensure proper security practices such as password
encryption methods, login retries, etc.