### PR TITLE
execFileToBuffers and sshd example

### DIFF
--- a/bundle.list
+++ b/bundle.list
@@ -108,6 +108,8 @@
 ./hostinfo/who.lua
 ./hostinfo/date.lua
 ./hostinfo/sysctl.lua
+./hostinfo/misc.lua
+./hostinfo/sshd.lua
 ./lua_modules/bourbon/init.lua
 ./lua_modules/bourbon/lib/asserts.lua
 ./lua_modules/bourbon/lib/context.lua

--- a/hostinfo/all.lua
+++ b/hostinfo/all.lua
@@ -26,5 +26,6 @@ return {
   require('./system'),
   require('./who'),
   require('./date'),
-  require('./sysctl')
+  require('./sysctl'),
+  require('./sshd')
 }

--- a/hostinfo/misc.lua
+++ b/hostinfo/misc.lua
@@ -1,0 +1,59 @@
+--[[
+Copyright 2015 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local table = require('table')
+local misc = require('/base/util/misc')
+local async = require('async')
+local childProcess = require('childprocess')
+
+local function execFileToBuffers(command, args, options, callback)
+  local child, stdout, stderr, exitCode
+
+  stdout = {}
+  stderr = {}
+  callback = misc.fireOnce(callback)
+
+  child = childProcess.spawn(command, args, options)
+  child.stdout:on('data', function (chunk)
+    table.insert(stdout, chunk)
+  end)
+  child.stderr:on('data', function (chunk)
+    table.insert(stderr, chunk)
+  end)
+
+  async.parallel({
+    function(callback)
+      child.stdout:on('end', callback)
+    end,
+    function(callback)
+      child.stderr:on('end', callback)
+    end,
+    function(callback)
+      local onExit
+      function onExit(code)
+        exitCode = code
+        callback()
+      end
+
+      child:on('exit', onExit)
+    end
+  }, function(err)
+    callback(err, exitCode, table.concat(stdout, ""), table.concat(stderr, ""))
+  end)
+end
+
+
+return {execFileToBuffers=execFileToBuffers}

--- a/hostinfo/sshd.lua
+++ b/hostinfo/sshd.lua
@@ -1,0 +1,61 @@
+--[[
+Copyright 2015 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+local HostInfo = require('./base').HostInfo
+
+local string = require('string')
+local fmt = require('string').format
+local table = require('table')
+local os = require('os')
+local execFileToBuffers = require('./misc').execFileToBuffers
+
+--[[ SSHd Variables ]]--
+local Info = HostInfo:extend()
+function Info:initialize()
+  HostInfo.initialize(self)
+end
+
+function Info:run(callback)
+
+  local function execCb(err, exitcode, stdout_data, stderr_data)
+    local line
+    self._error = err
+
+    p({err=err, exitcode=exitcode, stdout=stdout_data, stderr=stderr_data})
+
+    for line in stdout_data:gmatch("[^\r\n]+") do
+      line = line:gsub("^%s*(.-)%s*$", "%1")
+      local a, b, key, value = line:find("(.*)%s(.*)")
+      if key ~= nil then
+        local obj = {}
+        obj[key] = value
+        table.insert(self._params, obj)
+      end
+    end
+  end
+
+  command = 'sshd'
+  args = {'-z'}
+  options = {}
+
+  execFileToBuffers(command, args, options, execCb)
+
+end
+
+function Info:getType()
+  return 'SSHD'
+end
+
+return Info

--- a/hostinfo/sshd.lua
+++ b/hostinfo/sshd.lua
@@ -33,7 +33,7 @@ function Info:run(callback)
     local line
     self._error = err
 
-    p({err=err, exitcode=exitcode, stdout=stdout_data, stderr=stderr_data})
+    --p({err=err, exitcode=exitcode, stdout=stdout_data, stderr=stderr_data})
 
     for line in stdout_data:gmatch("[^\r\n]+") do
       line = line:gsub("^%s*(.-)%s*$", "%1")
@@ -44,11 +44,12 @@ function Info:run(callback)
         table.insert(self._params, obj)
       end
     end
+    callback()
   end
 
-  command = 'sshd'
-  args = {'-z'}
-  options = {}
+  local command = 'sshd'
+  local args = {'-T'}
+  local options = {}
 
   execFileToBuffers(command, args, options, execCb)
 


### PR DESCRIPTION
This is an example for the WALDO team to simplify hostinfo development in the case of spawning a process and reading its output.