### PR TITLE
line emitter optimizations

### DIFF
--- a/lua_modules/line-emitter/lib/emitter.lua
+++ b/lua_modules/line-emitter/lib/emitter.lua
@@ -1,6 +1,5 @@
 --[[
 Copyright 2015 Virgo Agent Toolkit Authors
-Copyright Tomaz Muraus
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lua_modules/line-emitter/lib/emitter.lua
+++ b/lua_modules/line-emitter/lib/emitter.lua
@@ -1,36 +1,60 @@
+--[[
+Copyright 2015 Virgo Agent Toolkit Authors
+Copyright Tomaz Muraus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
 local iStream = require('core').iStream
 
-local exports = {}
+local function gsplit2(s, sep)
+  local lasti, done, g = 1, false, s:gmatch('(.-)'..sep..'()')
+  return function()
+    if done then return end
+    local v,i = g()
+    if s == '' or sep == '' then done = true return s end
+    if v == nil then done = true return -1, s:sub(lasti) end
+    lasti = i
+    return v
+  end
+end
 
 local LineEmitter = iStream:extend()
 
-function LineEmitter:initialize(initialBuffer)
-  self._buffer = initialBuffer and initialBuffer or ''
+function LineEmitter:initialize(initialBuffer, options)
+  options = options or {}
+  self._buffer = initialBuffer or ''
+  self._includeNewLine = options.includeNewLine
 end
 
 function LineEmitter:write(chunk)
-  local line
+  if self.buffer then 
+    chunk = self.buffer .. chunk
+  end
 
-  self._buffer = self._buffer .. chunk
-
-  line = self:_popLine()
-  while line do
-    self:emit('data', line)
-    line = self:_popLine()
+  for line, last in gsplit2(chunk, '[\n]') do
+    if type(line) == 'number' then
+      self.buffer = last
+    else
+      if self._includeNewLine then
+        self:emit('data', line .. '\n')
+      else
+        self:emit('data', line)
+      end
+    end
   end
 end
 
-function LineEmitter:_popLine()
-  local line = false
-  local index = self._buffer:find('\n')
-
-  if index then
-    line = self._buffer:sub(0, index - 1)
-    self._buffer = self._buffer:sub(index + 1)
-  end
-
-  return line
-end
-
+local exports = {}
 exports.LineEmitter = LineEmitter
 return exports


### PR DESCRIPTION
I profiled the Line-Emitter subsystem and found out the parsing on 30 MB of
```abcdefghijklmnopqrstuvwxyz\n``` were using 700 MB - 1000 MB of memory. The plugin architecture reads stdout and stderr from processes, and even though plugins do not usually emit 30 MB worth of data, enough plugins and enough lines of data will use a significant amount of RAM. This PR optimizes the line splits with ```gmatch``` so it get's jitted, parsed within C, and does not use unnecessary memory copies. The same test on 30 MB of the alphabet with this PR resulted in memory usage of 30 MB.