### PR TITLE
jitter the check schedule

### DIFF
--- a/check/base.lua
+++ b/check/base.lua
@@ -48,6 +48,8 @@ local BaseCheck = Emitter:extend()
 local CheckResult = Object:extend()
 local Metric = Object:extend()
 
+local CHECK_SCHEDULE_JITTER = 15000 -- milliseconds
+
 local VALID_METRIC_TYPES = {'string', 'gauge', 'int32', 'uint32', 'int64', 'uint64', 'double'}
 
 -- Default check status
@@ -74,7 +76,6 @@ local function getMetricType(value)
     end
   end
 end
-
 
 function BaseCheck:initialize(params)
   self.id = tostring(params.id)
@@ -213,9 +214,12 @@ function BaseCheck:schedule()
   local timeout = self.period * 1000
   if self._firstRun then
     self._firstRun = false
+    -- add jitter to the check period
     timeout = math.floor(timeout * math.random())
+  else
+    -- add jitter to the check period
+    timeout = timeout + math.random(1, CHECK_SCHEDULE_JITTER) 
   end
-
   self._log(logging.INFO, fmt('%s scheduled for %ss', self:toString(), timeout))
   self._timer = timer.setTimeout(timeout, utils.bind(BaseCheck._runCheck, self))
 end

--- a/lua_modules/line-emitter/lib/emitter.lua
+++ b/lua_modules/line-emitter/lib/emitter.lua
@@ -46,9 +46,13 @@ function LineEmitter:write(chunk)
       self.buffer = last
     else
       if self._includeNewLine then
-        self:emit('data', line .. '\n')
+        process.nextTick(function()
+          self:emit('data', line .. '\n')
+        end)
       else
-        self:emit('data', line)
+        process.nextTick(function()
+          self:emit('data', line)
+        end)
       end
     end
   end


### PR DESCRIPTION
All checks on the same period are getting ran at the same time... this PR 

* jitters the check period (period + [1 ms up to 15 seconds])
* optimizes the split stream implementation (less memory)
* the line-emitter pushes data to the nextTick