### PR TITLE
add a hostinfo check

### DIFF
--- a/check/hostinfo.lua
+++ b/check/hostinfo.lua
@@ -1,0 +1,54 @@
+--[[
+Copyright 2015 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+local SubProcCheck = require('./base').SubProcCheck
+local CheckResult = require('./base').CheckResult
+local hostinfoCreate = require('../hostinfo').create
+
+local HostInfoCheck = SubProcCheck:extend()
+function HostInfoCheck:initialize(params)
+  SubProcCheck.initialize(self, params)
+  self.details = params.details or {}
+  self.type = self.details.type
+  self.params = self.details.params
+  self.multi_prefix = self.details.multi_prefix or 'multi_'
+end
+
+function HostInfoCheck:getType()
+  return 'agent.hostinfo'
+end
+
+function HostInfoCheck:_runCheckInChild(callback)
+  local info = hostinfoCreate(self.type, self.params)
+  local function onInfo()
+    local cr = CheckResult:new(self, {})
+    cr:setAvailable()
+    if #info._params == 0 then -- flat
+      for k, v in pairs(info._params) do
+        cr:addMetric(k, nil, nil, v)
+      end
+    else -- multiple
+      for i, param in ipairs(info._params) do
+        for k, v in pairs(param) do
+          cr:addMetric(self.multi_prefix .. i .. '_' .. k, nil, nil, v)
+        end
+      end
+    end
+    callback(cr)
+  end
+  info:run(onInfo)
+end
+
+exports.HostInfoCheck = HostInfoCheck

--- a/check/hostinfo.lua
+++ b/check/hostinfo.lua
@@ -22,7 +22,7 @@ function HostInfoCheck:initialize(params)
   SubProcCheck.initialize(self, params)
   self.details = params.details or {}
   self.type = self.details.type
-  self.params = self.details.params
+  self.args = self.details.args
   self.multi_prefix = self.details.multi_prefix or 'multi_'
 end
 
@@ -31,7 +31,7 @@ function HostInfoCheck:getType()
 end
 
 function HostInfoCheck:_runCheckInChild(callback)
-  local info = hostinfoCreate(self.type, self.params)
+  local info = hostinfoCreate(self.type, self.args)
   local function onInfo()
     local cr = CheckResult:new(self, {})
     cr:setAvailable()

--- a/check/init.lua
+++ b/check/init.lua
@@ -21,6 +21,7 @@ local ApacheCheck = require('./apache').ApacheCheck
 local CpuCheck = require('./cpu').CpuCheck
 local DiskCheck = require('./disk').DiskCheck
 local FileSystemCheck = require('./filesystem').FileSystemCheck
+local HostInfoCheck = require('./hostinfo').HostInfoCheck
 local MemoryCheck = require('./memory').MemoryCheck
 local NetworkCheck = require('./network').NetworkCheck
 local MySQLCheck = require('./mysql').MySQLCheck
@@ -39,18 +40,20 @@ local Error = require('core').Error
 local merge = require('virgo/util/misc').merge
 
 local check_classes = {
+  ApacheCheck = ApacheCheck,
   CpuCheck = CpuCheck,
   DiskCheck = DiskCheck,
   FileSystemCheck = FileSystemCheck,
+  HostInfoCheck = HostInfoCheck,
+  LoadAverageCheck = LoadAverageCheck,
   MemoryCheck = MemoryCheck,
-  NetworkCheck = NetworkCheck,
   MySQLCheck = MySQLCheck,
+  NetworkCheck = NetworkCheck,
   PluginCheck = PluginCheck,
   RaxxenCheck = RaxxenCheck,
   RedisCheck = RedisCheck,
-  LoadAverageCheck = LoadAverageCheck,
-  ApacheCheck = ApacheCheck,
-  NullCheck = NullCheck}
+  NullCheck = NullCheck
+}
 check_classes = merge(check_classes, Windows.checks)
 
 local function create_map()

--- a/hostinfo/base.lua
+++ b/hostinfo/base.lua
@@ -21,8 +21,8 @@ local Object = require('core').Object
 -------------------------------------------------------------------------------
 
 local HostInfo = Object:extend()
-function HostInfo:initialize()
-  self._params = {}
+function HostInfo:initialize(params)
+  self._params = params or {}
   self._error = nil
 end
 

--- a/hostinfo/init.lua
+++ b/hostinfo/init.lua
@@ -45,14 +45,13 @@ function NilInfo:initialize()
 end
 
 --[[ Factory ]]--
-local function create(infoType)
+local function create(infoType, params)
   local klass = HOST_INFO_MAP[infoType]
   if klass then
     if klass.Info then
-      return klass.Info:new()
-    else
-      return klass:new()
+      return klass.Info:new(params)
     end
+    return klass:new(params)
   end
   return NilInfo:new()
 end
@@ -151,7 +150,6 @@ local function debugInfoAllSize(callback)
 end
 
 --[[ Exports ]]--
-local exports = {}
 exports.create = create
 exports.classes = classes
 exports.getTypes = getTypes
@@ -162,4 +160,3 @@ exports.debugInfoAllToFile = debugInfoAllToFile
 exports.debugInfoAllToFolder = debugInfoAllToFolder
 exports.debugInfoAllTime = debugInfoAllTime
 exports.debugInfoAllSize = debugInfoAllSize
-return exports

--- a/hostinfo/init.lua
+++ b/hostinfo/init.lua
@@ -27,8 +27,8 @@ local function create_class_info()
   local types = {}
   for x, klass in pairs(classes) do
     if klass.Info then klass = klass.Info end
-    map[klass.getType()] = klass
-    table.insert(types, klass.getType())
+    map[klass.getType():upper()] = klass
+    table.insert(types, klass.getType():upper())
   end
   return {map = map, types = types}
 end
@@ -46,7 +46,7 @@ end
 
 --[[ Factory ]]--
 local function create(infoType, params)
-  local klass = HOST_INFO_MAP[infoType]
+  local klass = HOST_INFO_MAP[infoType:upper()]
   if klass then
     if klass.Info then
       return klass.Info:new(params)

--- a/runners/check_runner.lua
+++ b/runners/check_runner.lua
@@ -64,10 +64,17 @@ function CheckRunner:run(callback)
     print('Invalid Check Parameters')
     process:exit(1)
   end
-  check:_runCheckInChild(function(cr)
-    self._cr = cr
-    callback(nil)
-  end)
+  if check._runCheckInChild then
+    check:_runCheckInChild(function(cr)
+      self._cr = cr
+      callback(nil)
+    end)
+  else
+    check:run(function(cr)
+      self._cr = cr
+      callback(nil)
+    end)
+  end
 end
 
 function CheckRunner:reportError(err, callback)

--- a/tests/test-check.lua
+++ b/tests/test-check.lua
@@ -33,6 +33,7 @@ local MetricsRequest = require('../protocol/virgo_messages').MetricsRequest
 local Metric = require('../check/base').Metric
 local NetworkCheck = require('../check/network').NetworkCheck
 local PluginCheck = require('../check/plugin').PluginCheck
+local HostInfoCheck = require('../check/hostinfo').HostInfoCheck
 
 _G.TEST_DIR = 'tests/tmpdir'
 constants:setGlobal('DEFAULT_CUSTOM_PLUGINS_PATH', _G.TEST_DIR)
@@ -542,5 +543,45 @@ require('tap')(function(test)
         assert(metrics['none']['metric2'].v == '100')
       end)
     }, expect)
+  end)
+
+  test('test nonexistant hostinfo', function(expect)
+    local check = HostInfoCheck:new({ details = {type = 'NON_EXISTANT' }})
+    check:run(expect(function(cr)
+      p(cr:serialize())
+      assert(cr:getState() == 'unavailable')
+    end))
+  end)
+
+  test('test nonexistant hostinfo (lower)', function(expect)
+    local check = HostInfoCheck:new({ details = {type = 'cpu' }})
+    check:run(expect(function(cr)
+      assert(cr:getState() == 'available')
+      p(cr:getMetrics())
+    end))
+  end)
+
+  test('test cpu hostinfo (upper)', function(expect)
+    local check = HostInfoCheck:new({ details = {type = 'CPU' }})
+    check:run(expect(function(cr)
+      assert(cr:getState() == 'available')
+      p(cr:serialize())
+    end))
+  end)
+
+  test('test memory hostinfo', function(expect)
+    local check = HostInfoCheck:new({ details = {type = 'MEMORY' }})
+    check:run(expect(function(cr)
+      assert(cr:getState() == 'available')
+      p(cr:serialize())
+    end))
+  end)
+
+  test('test hostinfo', function(expect)
+    local check = HostInfoCheck:new({ details = {type = 'DATE' }})
+    check:run(expect(function(cr)
+      assert(cr:getState() == 'available')
+      p(cr:serialize())
+    end))
   end)
 end)


### PR DESCRIPTION
Features:
- Run's as a subprocess
- Details for the check can include parameters (details.params), the hostinfo type (details.type), and a multi prefix (details.multi_prefix) if the hostinfo contains multiple results

```
RAX_DETAILS_TYPE=MEMORY build/rackspace-monitoring-agent -e check_runner -x agent.hostinfo
state available
status success
metric used_percent double 64.622020721436
metric swap_free int64 1144258560
metric free int64 43073536
metric swap_page_in int64 187140033
metric swap_used int64 1003225088
metric swap_total int64 2147483648
metric actual_used int64 5550989312
metric swap_page_out int64 846881
metric total int64 8589934592
metric ram int64 8192
metric free_percent double 35.377979278564
metric actual_free int64 3038945280
metric used int64 8546861056
```

```
RAX_DETAILS_TYPE=CPU RAX_DETAILS_MULTI_PREFIX='cpu_' build/rackspace-monitoring-agent -e check_runner -x agent.hostinfo
state available
status success
metric cpu_2_name string cpu.1
metric cpu_7_model string MacBookPro9,1
metric cpu_1_idle int64 971361470
metric cpu_2_irq int64 0
metric cpu_5_idle int64 1080006770
metric cpu_5_stolen int64 0
metric cpu_5_sys int64 29442050
metric cpu_8_sys int64 2814980
metric cpu_7_nice int64 0
metric cpu_7_vendor string Intel
...snip...
```
