### PR TITLE
refactor(hostinfo): Make the api consistent across hostinfo checks

### DIFF
--- a/hostinfo/cron.lua
+++ b/hostinfo/cron.lua
@@ -21,6 +21,7 @@ local async = require('async')
 local fs = require('fs')
 local path = require('path')
 local sigar = require('sigar')
+local logWarn = require('./misc').logWarn
 
 --[[ Pluggable auth modules ]]--
 local Info = HostInfo:extend()
@@ -75,12 +76,12 @@ function Info:run(callback)
     async.forEachLimit(files, 5, function(file, cb)
       readCast(path.join(cdir, file), errTable, self._params, parseLine, cb)
     end, function()
-      if self._params ~= nil then
-        table.insert(self._params, {
-          warnings = errTable
-        })
-      else
-        self._error = errTable
+      if errTable and next(errTable) then
+        if not self._params or not next(self._params) then
+          self._error = errTable
+        else
+          logWarn(errTable)
+        end
       end
       return callback()
     end)

--- a/hostinfo/fstab.lua
+++ b/hostinfo/fstab.lua
@@ -15,6 +15,7 @@ limitations under the License.
 ]]--
 local los = require('los')
 local readCast = require('./misc').readCast
+local logWarn = require('./misc').logWarn
 
 --[[ Check fstab ]]--
 local HostInfo = require('./base').HostInfo
@@ -37,15 +38,17 @@ function Info:run(callback)
   end
 
   local function cb()
-    if self._params == nil then
-      self._error = errTable
+    if errTable and next(errTable) then
+      if not self._params or not next(self._params) then
+        self._error = errTable
+      else
+        logWarn(errTable)
+      end
     end
     return callback()
   end
 
   local errTable = {}
-
-
   readCast('/etc/fstab', errTable, self._params, casterFunc, cb)
 end
 

--- a/hostinfo/misc.lua
+++ b/hostinfo/misc.lua
@@ -19,6 +19,9 @@ local async = require('async')
 local childProcess = require('childprocess')
 local string = require('string')
 local fs = require('fs')
+local logging = require('logging')
+local los = require('los')
+local join = require('path').join
 
 local function execFileToBuffers(command, args, options, callback)
   local child, stdout, stderr, exitCode
@@ -132,5 +135,24 @@ local function asyncSpawn(dataArr, spawnFunc, successFunc, finalCb)
   end)
 end
 
+local function logWarn(errTable)
+  local logpath
+  if los.type() ~= 'linux' then
+    -- TODO: properly implement logging in windows
+    logpath = './'
+  else
+    logpath = '/var/log'
+  end
+  logpath = join(logpath, 'rackspace-monitoring-agent-hostinfo.log')
+  logging.init(logging.StdoutFileLogger:new({
+    path = logpath
+  }))
+  logging.warning(table.concat(errTable, '/n'))
+end
 
-return {execFileToBuffers=execFileToBuffers, readCast=readCast, asyncSpawn=asyncSpawn}
+return {
+  execFileToBuffers=execFileToBuffers,
+  readCast=readCast,
+  asyncSpawn=asyncSpawn,
+  logWarn=logWarn
+}


### PR DESCRIPTION
Make these checks return a list of objects, stop storing data like filenames in keys, instead we'll go with having a key called name which stores that data instead. And we'll log warning instead of sending them downstream.