### PR TITLE
fix(hostinfo): add pcall around hostinfo:run()

### DIFF
--- a/hostinfo/autoupdates.lua
+++ b/hostinfo/autoupdates.lua
@@ -27,7 +27,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for Packages'
     return callback()

--- a/hostinfo/base.lua
+++ b/hostinfo/base.lua
@@ -32,8 +32,19 @@ function HostInfo:serialize()
   }
 end
 
+function HostInfo:getType()
+  return 'HostInfo'
+end
+
 function HostInfo:run(callback)
-  callback()
+  local status, err = pcall(function()
+    if self._run then self:_run(callback) else callback() end
+  end)
+  if not status then
+    self._params = {}
+    self._error = err
+    callback()
+  end
 end
 
 exports.HostInfo = HostInfo

--- a/hostinfo/cron.lua
+++ b/hostinfo/cron.lua
@@ -28,7 +28,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for pluggable auth module definitions'
     return callback()

--- a/hostinfo/cve.lua
+++ b/hostinfo/cve.lua
@@ -27,7 +27,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for pluggable auth module definitions'
     return callback()

--- a/hostinfo/deleted_libs.lua
+++ b/hostinfo/deleted_libs.lua
@@ -25,7 +25,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for deleted libraries check'
     return callback()

--- a/hostinfo/fileperms.lua
+++ b/hostinfo/fileperms.lua
@@ -28,7 +28,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for file permissions'
     return callback()

--- a/hostinfo/fstab.lua
+++ b/hostinfo/fstab.lua
@@ -23,7 +23,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for fstab'
     return callback()

--- a/hostinfo/ip4routes.lua
+++ b/hostinfo/ip4routes.lua
@@ -27,7 +27,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for routs'
     return callback()

--- a/hostinfo/ip6routes.lua
+++ b/hostinfo/ip6routes.lua
@@ -27,7 +27,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for routs'
     return callback()

--- a/hostinfo/ip6tables.lua
+++ b/hostinfo/ip6tables.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for last logins'
     return callback()

--- a/hostinfo/iptables.lua
+++ b/hostinfo/iptables.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for last logins'
     return callback()

--- a/hostinfo/kernel_modules.lua
+++ b/hostinfo/kernel_modules.lua
@@ -25,7 +25,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
 
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for Kernel modules'

--- a/hostinfo/last_logins.lua
+++ b/hostinfo/last_logins.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for last logins'
     return callback()

--- a/hostinfo/login.lua
+++ b/hostinfo/login.lua
@@ -25,7 +25,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
 
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for Login Definitions'

--- a/hostinfo/packages.lua
+++ b/hostinfo/packages.lua
@@ -27,7 +27,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for Packages'
     return callback()

--- a/hostinfo/pam.lua
+++ b/hostinfo/pam.lua
@@ -28,7 +28,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for pluggable auth module definitions'
     return callback()

--- a/hostinfo/passwd.lua
+++ b/hostinfo/passwd.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for passwdstatus'
     return callback()

--- a/hostinfo/remote_services.lua
+++ b/hostinfo/remote_services.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for remote services'
     return callback()

--- a/hostinfo/services.lua
+++ b/hostinfo/services.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for services'
     return callback()

--- a/hostinfo/sshd.lua
+++ b/hostinfo/sshd.lua
@@ -25,7 +25,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() == 'win32' then
     self._error = 'Unsupported OS for sshd'
     return callback()

--- a/hostinfo/sysctl.lua
+++ b/hostinfo/sysctl.lua
@@ -33,7 +33,7 @@ function Info:_run(callback)
     return
   end
 
-  local child = spawn('sysctl', {'-A'}, {})
+  local child = spawn('sysctl', {'-A'}, { env = process.env })
   local data = ''
 
   child.stdout:on('data', function(chunk)

--- a/hostinfo/sysctl.lua
+++ b/hostinfo/sysctl.lua
@@ -26,7 +26,7 @@ function Info:initialize()
   HostInfo.initialize(self)
 end
 
-function Info:run(callback)
+function Info:_run(callback)
   if los.type() ~= 'linux' then
     self._error = 'Unsupported OS for sysctl'
     callback()

--- a/tests/test-hostinfo.lua
+++ b/tests/test-hostinfo.lua
@@ -17,9 +17,23 @@ limitations under the License.
 require('tap')(function(test)
   local hostinfo = require('../hostinfo')
   for _, type in pairs(hostinfo.getTypes()) do
-    test('test ' .. type, function()
+    test('test ' .. type, function(expect)
       local info = hostinfo.create(type)
-      info:run(p)
+      info:run(expect(function() assert(info._params) end))
     end)
   end
+
+  test('test for bad hostinfo', function(expect)
+    local info
+    local errMsg = 'this is an error'
+    local function onRun()
+      assert(info._error:find(errMsg))
+    end
+    info = hostinfo.create('nil')
+    info._run = function(self, callback)
+      error(errMsg)
+    end
+    info:run(expect(onRun))
+  end)
+
 end)


### PR DESCRIPTION
*Why*
Makes sure the agent can't crash with failing hostinfo's.

*How*
Adds a pcall around the hostinfo run functions to capture any errors