### PR TITLE
feat(hostinfo/all)

### DIFF
--- a/hostinfo/README.md
+++ b/hostinfo/README.md
@@ -94,6 +94,8 @@ Examples:
 ## Current list of available hostinfo checks
 
 The best resource for figuring out the most up-to-date list of available hostinfos is to look at [all.lua](https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/blob/master/hostinfo/all.lua)
+All also acts as a special hostinfo check type which will return data from all the hostinfos with the hostinfo types as  
+keys and the metrics returned as values.  
 
 As of this writing, here is the list: (Generated using debugging examples #3 and #7 above.)
 The items in the list are linked to sample debug output for themselves. 

--- a/hostinfo/init.lua
+++ b/hostinfo/init.lua
@@ -18,9 +18,9 @@ local json = require('json')
 local los = require('los')
 local async = require('async')
 local path = require('path')
-local HostInfo = require('./base').HostInfo
-local classes = require('./all')
 local uv = require('uv')
+local HostInfo = require('./base').HostInfo
+local classes = require('./all').classes
 
 local function create_class_info()
   local map = {}


### PR DESCRIPTION
Augment hostinfo/all.lua to act as both an index and a standalone hostinfo check type which will run and retrieve data from all hostinfos.
Useful for preventing network overhead and record keeping of new hostinfo check types for cases where we need to get the whole gamut of data about the host (elasticsearch/waldo etc)