### PR TITLE
feat(hostinfo/debug): Added a couple of benchmarking utils for output size and run time

### DIFF
--- a/hostinfo/README.md
+++ b/hostinfo/README.md
@@ -80,6 +80,16 @@ Examples:
   ```
   rackspace-monitoring-agent -e hostinfo_runner -d -F debug
   ```
+  
+  8. The -T flag will benchmark all the hostinfos and return a list of hostinfos and their run times derived using luas os.clock util.
+  ```
+  rackspace-monitoring-agent -e hostinfo_runner -T
+  ```
+  
+  9. The -S flag will benchmark output file sizes of all hostinfos and return a list thereof. Be forewarned that this isn't very accurate since data returned varies greatly depending on host configuration  
+  ```
+  rackspace-monitoring-agent -e hostinfo_runner -S
+  ```
 
 ## Current list of available hostinfo checks
 

--- a/hostinfo/init.lua
+++ b/hostinfo/init.lua
@@ -20,6 +20,7 @@ local async = require('async')
 local path = require('path')
 local HostInfo = require('./base').HostInfo
 local classes = require('./all')
+local uv = require('uv')
 
 local function create_class_info()
   local map = {}
@@ -118,10 +119,10 @@ end
 local function debugInfoAllTime(callback)
   local data = {}
   async.forEachLimit(HOST_INFO_TYPES, 5, function(infoType, cb)
-    local start = os.clock()
+    local start = uv.hrtime()
     debugInfo(infoType, function(_)
-      local endTime = os.clock() - start
-      data[infoType] = endTime
+      local endTime = uv.hrtime() - start
+      data[infoType] = endTime / 10000
       cb()
     end)
   end, function()

--- a/runners/hostinfo_runner.lua
+++ b/runners/hostinfo_runner.lua
@@ -24,6 +24,10 @@ local function run(...)
   .describe("d", "Generate documentation")
   .usage('Usage: -t')
   .describe("t", "Print all implemented hostinfo types")
+  .usage('Usage: -T')
+  .describe("T", "Print run times for all implemented hostinfo types")
+  .usage('Usage: -S')
+  .describe("S", "Print size in bytes for all implemented hostinfo types")
   .usage('Usage: -x [Host Info Type]')
   .describe("x", "Host info type to run")
   .usage('Usage: -f [File name]')
@@ -59,6 +63,10 @@ local function run(...)
     return
   elseif args.t then
     return print(table.concat(HostInfo.getTypes(), '\n'))
+  elseif args.T then
+    HostInfo.debugInfoAllTime(print)
+  elseif args.S then
+    HostInfo.debugInfoAllSize(print)
   else
     print(argv._usage)
     return process:exit(0)


### PR DESCRIPTION
People have been asking me questions like:
- Whats the average/max hostinfo return data size?
- Whats the average/overall run time for the hostinfos?

These two should help me more accurately answer those questions instead of taking a guess.
Should also help us optimize scheduling for data gathering i.e. run the super slow/large ones only once a day to cache and the others can be cached several times a day or per hour.