### PR TITLE
plugin: close stdin to prevent hangs on windows

### DIFF
--- a/check/base.lua
+++ b/check/base.lua
@@ -428,6 +428,7 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
   self._log(logging.DEBUG, fmt("%s: starting process", exePath))
 
   local child = childprocess.spawn(exePath, exeArgs, { env = self:_childEnv() })
+  child.stdin:destroy() -- close stdin for windows and ruby compatibility
 
   local pluginTimeout = timer.setTimeout(self._timeout, function()
     local timeoutSeconds = (self._timeout / 1000)


### PR DESCRIPTION
*Why*
Some powershell versions require stdin to be closed to exit correctly.
In addition, some ruby variants crash when stdin is not closed.

Fixes custom plugins.