### PR TITLE
private_zone: add private zone configuration and feature

### DIFF
--- a/agent.lua
+++ b/agent.lua
@@ -232,6 +232,12 @@ function Agent:_preConfig(callback)
   -- Disable Features
   features.disableWithOption(self._config['upgrade'], 'upgrades', true)
   features.disableWithOption(self._config['health'], 'health')
+
+  -- Set Feature Params
+  features.setParams('poller', {
+    private_zone = self._config['private_zone']
+  })
+
   self._features = features.get()
 
   async.series({

--- a/features.lua
+++ b/features.lua
@@ -13,14 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 --]]
+
+local us = require('virgo/util/underscore')
+
 local FEATURE_UPGRADES = { name = 'upgrades', version = '1.0.0' }
 local FEATURE_CONFD = { name = 'confd', version = '1.0.0' }
 local FEATURE_HEALTH = { name = 'health', version = '1.0.0' }
+local FEATURE_POLLER = { name = 'poller', version = '1.0.0' }
 
 local FEATURES = {
   FEATURE_UPGRADES,
   FEATURE_CONFD,
-  FEATURE_HEALTH 
+  FEATURE_HEALTH,
+  FEATURE_POLLER
 }
 
 local function disable(name, remove)
@@ -30,7 +35,7 @@ local function disable(name, remove)
         table.remove(FEATURES, i)
       else
         v.disabled = true
-      end 
+      end
       break
     end
   end
@@ -52,6 +57,13 @@ local function disableWithOption(option, name, remove)
   end
 end
 
+local function setParams(name, params)
+  local feature = get(name)
+  if not feature then return end
+  us.extend(feature, { params = params })
+end
+
 exports.get = get
+exports.setParams = setParams
 exports.disable = disable
 exports.disableWithOption = disableWithOption

--- a/main.lua
+++ b/main.lua
@@ -232,6 +232,7 @@ local function start(...)
     virgo.config['insecure'] = virgo.config['monitoring_insecure']
     virgo.config['debug'] = virgo.config['monitoring_debug']
     virgo.config['health'] = virgo.config['monitoring_health']
+    virgo.config['private_zone'] = virgo.config['monitoring_private_zone']
 
     -- Set debug logging based on the config file
     if virgo.config['debug'] == 'true' then


### PR DESCRIPTION
*What*
Adds `monitoring_private_zone` to the config file and propagates through to the AEP via the features.