### PR TITLE
fix(hostinfo/base)

### DIFF
--- a/hostinfo/base.lua
+++ b/hostinfo/base.lua
@@ -97,16 +97,20 @@ function HostInfo:_pushError(err)
 end
 
 function HostInfo:_pushParams(err, data)
-    -- flatten single entry objects
-    if type(data) == 'table' then
-      if #data == 1 then data = data[1] end
-    end
-    self._params = data
-    if err then
+  -- flatten single entry objects
+  if type(data) == 'table' then
+    if #data == 1 then data = data[1] end
+  end
+  self._params = data
+  if err then
+    if type(err) == 'table' and next(err) then
       self:_pushError(err)
-    elseif not err and not data or not next(data) then
+    elseif type(err) == 'string' and #err > 0 then
       self:_pushError(err)
     end
+  elseif not err and not data or not next(data) then
+    self:_pushError(err)
+  end
 end
 
 


### PR DESCRIPTION
Prevent erronously added undefined error messeages from being added to our response
Sometimes working hostinfos that cast their errors out as objects will have a no error or data returned error in their response. 