### PR TITLE
fix(hostinfo/postfix): fix typo error in default message when postfix isnt running

### DIFF
--- a/hostinfo/postfix.lua
+++ b/hostinfo/postfix.lua
@@ -73,7 +73,7 @@ function Info:_run(callback)
       if not out or not next(out) then
         cb(nil, {
           process = {
-            process = 'Postfix is not misc.running'
+            process = 'Postfix is not running'
           }
         })
       else


### PR DESCRIPTION
Default message when postfix isnt running was a little wrong.