### PR TITLE
feat(hostinfo/hostname): Add a hostinfo for fetching hostname

### DIFF
--- a/hostinfo/README.md
+++ b/hostinfo/README.md
@@ -176,6 +176,8 @@ The items in the list are linked to sample debug output for themselves.
   Returns information such as version, type (HHVM/PHP), and errors about php. Use the CLI and log files to extract this information  
 - [POSTFIX](https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/blob/master/hostinfo/debug/POSTFIX.json)  
   Checks the status of the postfix mail server  
+- [HOSTNAME](https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/blob/master/hostinfo/debug/HOSTNAME.json)  
+  Returns the hostname  
   
 ## Notes for developers
 

--- a/hostinfo/all.lua
+++ b/hostinfo/all.lua
@@ -53,5 +53,6 @@ return {
   require('./wordpress'),
   require('./magento'),
   require('./php'),
-  require('./postfix')
+  require('./postfix'),
+  require('./hostname')
 }

--- a/hostinfo/debug/HOSTNAME.json
+++ b/hostinfo/debug/HOSTNAME.json
@@ -1,0 +1,8 @@
+{"Debug":{"InfoType":"HOSTNAME", "OS":"linux"}}
+
+{
+  "metrics":{
+  	"hostname": "generic-hostname"
+  	},
+  "timestamp":1452033979000
+}

--- a/hostinfo/hostname.lua
+++ b/hostinfo/hostname.lua
@@ -1,0 +1,64 @@
+--[[
+Copyright 2015 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+local HostInfo = require('./base').HostInfo
+local misc = require('./misc')
+local Transform = require('stream').Transform
+
+--------------------------------------------------------------------------------------------------------------------
+local Reader = Transform:extend()
+function Reader:initialize()
+  Transform.initialize(self, {objectMode = true})
+end
+
+function Reader:_transform(line, cb)
+  self:push({hostname = line})
+  return cb()
+end
+--------------------------------------------------------------------------------------------------------------------
+
+--[[ Fetch this servers hostname ]]--
+local Info = HostInfo:extend()
+function Info:initialize(params)
+  HostInfo.initialize(self)
+end
+
+function Info:_run(callback)
+  local command = 'hostname'
+  local outTable, errTable = {}, {}
+
+  local function finalCb()
+    self:_pushParams(errTable, outTable)
+    return callback()
+  end
+
+  local child = misc.run('sh', {'-c', command})
+  local reader = Reader:new()
+  child:pipe(reader)
+  reader:on('error', function(err) misc.safeMerge(errTable, err) end)
+  reader:on('data', function(datum) misc.safeMerge(outTable, datum) end)
+  reader:once('end', finalCb)
+end
+
+function Info:getPlatforms()
+  return {'linux'}
+end
+
+function Info:getType()
+  return 'HOSTNAME'
+end
+
+exports.Info = Info
+exports.Reader = Reader

--- a/static/tests/hostinfo/hostname_in.txt
+++ b/static/tests/hostinfo/hostname_in.txt
@@ -1,0 +1,1 @@
+generic-hostname

--- a/static/tests/hostinfo/hostname_out.txt
+++ b/static/tests/hostinfo/hostname_out.txt
@@ -1,0 +1,1 @@
+[{"hostname": "generic-hostname"}]

--- a/tests/test-hostinfo.lua
+++ b/tests/test-hostinfo.lua
@@ -47,7 +47,9 @@ require('tap')(function(test)
     local outFixture = hostinfoFixtureDir[testFileName..'_out.txt']
     local cb = expect(function()
       local outFixtureTable = json.parse(outFixture)
-      assert(is_equal(outFixtureTable, outTable), 'not ok: outFixture and outTable dont match')
+      local outTableStr = json.stringify(outTable)
+      local errMsg = 'Not ok: outFixture and outTable dont match.\nExpected:'..outFixture..'Got:'..outTableStr
+      assert(is_equal(outFixtureTable, outTable), errMsg)
       assert(#errTable==0, 'Not ok: errtable is not 0 length')
     end)
     inFixture:pipe(reader)
@@ -78,7 +80,8 @@ require('tap')(function(test)
     'sshd',
     'sysctl',
     'magento',
-    'lsyncd'
+    'lsyncd',
+    'hostname'
   }
 
   for _, checkName in pairs(hostinfoChecks) do


### PR DESCRIPTION
This pr also changes the test-hostinfo file to now say whats wrong. 
i.e.
`      local errMsg = 'Not ok: outFixture and outTable dont match.\nExpected:'..outFixture..'Got:'..outTableStr
`
from
`
      local errMsg = 'Not ok: outFixture and outTable dont match.
`