### PR TITLE
fix(hostinfo/fileperms): Fix fileperms octalfileperms, 

### DIFF
--- a/hostinfo/fileperms.lua
+++ b/hostinfo/fileperms.lua
@@ -66,7 +66,7 @@ function Info:_run(callback)
             local obj = {}
             obj.fileName = file
             --[[Check file permissions, octal: 0777]]--
-            obj.octalFilePerms = band(fstat.mode, 511)
+            obj.octalFilePerms = string.format("%o", band(fstat.mode, 511))
             --[[Check if the file has a sticky id, octal: 01000]]--
             obj.stickyBit = band(fstat.mode, 512) ~= 0
             --[[Check if file has a set group id, octal: 02000]]--


### PR DESCRIPTION
format as unsigned octal instead of decimal.
Files with octal == 644 were coming back as 420. 