### PR TITLE
Update maximum check period to 1 day instead of 30 minutes

### DIFF
--- a/constants.lua
+++ b/constants.lua
@@ -33,7 +33,7 @@ constants:setGlobal('DEFAULT_CUSTOM_PLUGINS_PATH', path.join(const.LIBRARY_DIR, 
 constants:setGlobal('DEFAULT_LOCK_FILE_PATH', '/var/run/rackspace-monitoring-agent.lock')
 constants:setGlobal('DEFAULT_PID_FILE_PATH', '/var/run/rackspace-monitoring-agent.pid')
 constants:setGlobal('DEFAULT_PLUGIN_TIMEOUT', 60 * 1000)
-constants:setGlobal('MAX_CHECK_PERIOD', 1800000) -- 30 minute check period (milliseconds)
+constants:setGlobal('MAX_CHECK_PERIOD', 86400000) -- 1 day check period (milliseconds)
 constants:setGlobal('METRIC_STATUS_MAX_LENGTH', 256)
 constants:setGlobal('PLUGIN_TYPE_MAP', {string = 'string', int = 'int64', float = 'double', gauge = 'gauge'})
 constants:setGlobal('SETUP_AUTH_CHECK_INTERVAL', 1000)


### PR DESCRIPTION
# What

    Increase the maximum check period to 86400 seconds (1 day)

# How

    Update the variable in agent code (and a partner PR for the ele repository)

## How to test

    Create a check with a check period great than 1800 (and less than or equal to 86400).

# Why

    Rackspace Metrics has a test that they want to run daily and not run on a 30 minute interval.  A test like an SSL certificate check (checking attributes like expiration) is another example of checks that shouldn't and don't need to be run on a 30 minute interval.

# TODO

    Needs double checking by someone familiar with the code to make sure I didn't miss any dependencies.  
    Has a companion PR in the ele repo that will need to get approved.
    Determine the ordering of how these should be merged and deployed (probably ele first, then agent)
    Create a story with Intelligence to change their UI after these have landed.
    Create a story or task to update public docs for Rackspace Monitoring if we want to make this public.
