### PR TITLE
add restartsec to systemd options

### DIFF
--- a/cmake/package/systemd/service.in
+++ b/cmake/package/systemd/service.in
@@ -5,6 +5,7 @@ After=network-online.target
 [Service]
 ExecStart=/usr/bin/@APP_NAME@ -l /var/log/@APP_NAME@.log --production --exit-on-upgrade
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Adding `RestartSec` will configure systemd to always try to restart the agent and not give up.