### PR TITLE
add a sample to the hostinfo

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,4 +5,4 @@ globals = {
   "virgo_paths", 'TEST_DIR'
 }
 unused_args = false
-ignore = { "122", "4.2", "431" }
+ignore = { "122", "4.2", "431", "631" }

--- a/hostinfo/cpu.lua
+++ b/hostinfo/cpu.lua
@@ -82,6 +82,7 @@ function Info:_run(callback)
     local diffResult = {}
     for cpuIndex in pairs(samples[1]) do
       local cpuDiff = {}
+      cpuDiff['name'] = samples[1][cpuIndex]['name']
       for _, v in pairs(DATA_FIELDS) do
         local cpuValue = samples[1][cpuIndex][v]
         local cpuValue2 = samples[2][cpuIndex][v]

--- a/hostinfo/cpu.lua
+++ b/hostinfo/cpu.lua
@@ -14,51 +14,86 @@ See the License for the specific language governing permissions and
 limitations under the License.
 --]]
 local HostInfo = require('./base').HostInfo
+local async = require('async')
 local sigar = require('sigar')
+local timer = require('timer')
+
+local SAMPLE_RATE = 350 -- ms
+local DATA_FIELDS = {
+  'idle',
+  'irq',
+  'nice',
+  'soft_irq',
+  'stolen',
+  'sys',
+  'total',
+  'user',
+  'wait'
+}
+local INFO_FIELDS = {
+  'mhz',
+  'model',
+  'total_cores',
+  'total_sockets',
+  'vendor'
+}
+
 
 --[[ Info ]]--
 local Info = HostInfo:extend()
 function Info:initialize()
   HostInfo.initialize(self)
 end
+
 function Info:_run(callback)
-  local ctx = sigar:new()
-  local cpus = ctx:cpus()
-  for i=1, #cpus do
-    local obj = {}
-    local info = cpus[i]:info()
-    local data = cpus[i]:data()
-    local name = 'cpu.' .. i - 1
-    local data_fields = {
-      'idle',
-      'irq',
-      'nice',
-      'soft_irq',
-      'stolen',
-      'sys',
-      'total',
-      'user',
-      'wait'
-    }
-    local info_fields = {
-      'mhz',
-      'model',
-      'total_cores',
-      'total_sockets',
-      'vendor'
-    }
-
-    for _, v in pairs(data_fields) do
-      obj[v] = data[v]
+  local samples = {}
+  local function sample(callback)
+    local ctx = sigar:new()
+    local cpus = ctx:cpus()
+    local result = {}
+    for i=1, #cpus do
+      local obj = {}
+      local info = cpus[i]:info()
+      local data = cpus[i]:data()
+      local name = 'cpu.' .. i - 1
+      for _, v in pairs(DATA_FIELDS) do
+        obj[v] = data[v]
+      end
+      for _, v in pairs(INFO_FIELDS) do
+        obj[v] = info[v]
+      end
+      obj['name'] = name
+      table.insert(result, obj)
     end
-    for _, v in pairs(info_fields) do
-      obj[v] = info[v]
-    end
-
-    obj['name'] = name
-    table.insert(self._params, obj)
+    table.insert(samples, result)
+    callback()
   end
-  callback()
+  async.series({
+    function(callback)
+      sample(callback)
+    end,
+    function(callback)
+      timer.setTimeout(SAMPLE_RATE, callback)
+    end,
+    function(callback)
+      sample(callback)
+    end
+  }, function()
+    local diffResult = {}
+    for cpuIndex in pairs(samples[1]) do
+      local cpuDiff = {}
+      for _, v in pairs(DATA_FIELDS) do
+        local cpuValue = samples[1][cpuIndex][v]
+        local cpuValue2 = samples[2][cpuIndex][v]
+        cpuDiff[v] = cpuValue2 - cpuValue
+      end
+      for _, v in pairs(INFO_FIELDS) do
+        cpuDiff[v] = samples[2][cpuIndex][v]
+      end
+      table.insert(self._params, cpuDiff)
+    end
+    callback()
+  end)
 end
 
 function Info:getType()

--- a/hostinfo/cpu.lua
+++ b/hostinfo/cpu.lua
@@ -79,7 +79,6 @@ function Info:_run(callback)
       sample(callback)
     end
   }, function()
-    local diffResult = {}
     for cpuIndex in pairs(samples[1]) do
       local cpuDiff = {}
       cpuDiff['name'] = samples[1][cpuIndex]['name']


### PR DESCRIPTION
result:

```lua
{
  "metrics":[{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.0",
      "wait":0,
      "user":10,
      "irq":0,
      "total":280,
      "stolen":0,
      "idle":250,
      "sys":20,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.1",
      "wait":0,
      "user":0,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":290,
      "sys":0,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.2",
      "wait":0,
      "user":10,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":270,
      "sys":10,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.3",
      "wait":0,
      "user":0,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":290,
      "sys":0,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.4",
      "wait":0,
      "user":20,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":260,
      "sys":10,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.5",
      "wait":0,
      "user":0,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":290,
      "sys":0,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.6",
      "wait":0,
      "user":0,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":280,
      "sys":10,
      "mhz":2500
    },{
      "soft_irq":0,
      "vendor":"Intel",
      "total_sockets":8,
      "nice":0,
      "model":"MacBookPro11,4",
      "total_cores":8,
      "name":"cpu.7",
      "wait":0,
      "user":0,
      "irq":0,
      "total":290,
      "stolen":0,
      "idle":290,
      "sys":0,
      "mhz":2500
    }],
  "timestamp":1490020330000
}
```