### PR TITLE
Fix docker-compose.yml syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 build:
   build: .
   environment:
-   TRAVIS: true
+   TRAVIS: "true"
   volumes:
    - .:/src


### PR DESCRIPTION
This commit fixes the following error:

```
$ docker-compose run build make clean
ERROR: The Compose file './docker-compose.yml' is invalid because:
build.environment.TRAVIS contains true, which is an invalid type, it should be a string, number, or a null
```