### PR TITLE
Declare xenstore utils dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ if (${SPECIFIC_SYSTEM_VERSION_NAME} MATCHES "^Linux")
 
     include(CreateRepo)
   elseif(${SPECIFIC_SYSTEM_PREFERED_CPACK_GENERATOR} MATCHES "DEB")
+    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "xenstore-utils (>= 4.8.0-1)")
     ### Control Files
     set(DEB_POSTRM ${GENERATED_PACKAGE_SCRIPTS}/debian/postrm)
     configure_file(${PACKAGE_SCRIPTS}/debian/postrm.in ${DEB_POSTRM})

--- a/cmake/repo/reprepro.in
+++ b/cmake/repo/reprepro.in
@@ -4,4 +4,3 @@ Architectures: i386 amd64 source
 Origin: Rackspace
 Description: Rackspace Cloud Monitoring Agent
 SignWith: D05AB914
-Depends: xenstore-utils

--- a/cmake/repo/reprepro.in
+++ b/cmake/repo/reprepro.in
@@ -4,3 +4,4 @@ Architectures: i386 amd64 source
 Origin: Rackspace
 Description: Rackspace Cloud Monitoring Agent
 SignWith: D05AB914
+Depends: xenstore-utils


### PR DESCRIPTION
The agent ultimately calls `xenstore-read name` which comes from the package xenstore-utils. That package apparently used to get pulled in by xe-guest-utiltiies, which is pre-installed on the Ubuntu distribution.