### PR TITLE
Bump to 2.6.18

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## rackspace-monitoring-agent-2.6.18
+
+* Bump virgo-base for connection handling fix
+
 ## rackspace-monitoring-agent-2.6.17
 
 * Fix RHEL7 build to avoid dynamic dependency on libuv

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "rackspace-monitoring-agent",
-  version = "2.6.17",
+  version = "2.6.18",
   luvi = {
     version = "2.7.6-2-sigar",
     flavor = "sigar",
@@ -9,7 +9,7 @@ return {
   dependencies = {
     "rphillips/options@0.0.5",
     "virgo-agent-toolkit/rackspace-monitoring-client@0.3",
-    "virgo-agent-toolkit/virgo@2.1.8",
+    "virgo-agent-toolkit/virgo@2.1.9",
     "kaustavha/luvit-walk@1",
   },
   files = {


### PR DESCRIPTION
Includes https://github.com/virgo-agent-toolkit/virgo-base-agent/pull/192

This pulls in the following commits to try and resolve an issue with proxy connections staying in a CLOSE_WAIT state.

https://github.com/luvit/luvit/pull/1031
https://github.com/luvit/luvit/pull/1032