### PR TITLE
Use the pinned LIT_VERSION in make.bat

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -29,7 +29,7 @@ GOTO :end
 
 :lit
 ECHO "Building lit"
-PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol =  'Tls12'; iex ((new-object net.webclient).DownloadString('https://github.com/luvit/lit/raw/master/get-lit.ps1'))"
+PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol =  'Tls12'; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/luvit/lit/%LIT_VERSION%/get-lit.ps1'))"
 if %errorlevel% neq 0 goto error
 GOTO :end
 


### PR DESCRIPTION
For Windows the `Make.bat` is used to simulate make on Linux. As a side effect, it's not as robust at using the versions declared in the wrapper build script -- in fact, it seems to pretty much ignore them. Worse still, the `get-lit` powershell script used in `make.bat` was always downloading the latest from master instead the version set at the top of `make.bat`. 

A mismatch in lit version would result in errors like this when running the agent:

```
...s64/home/Administrator/luvi-sigar/src/lua/luvibundle.lua:321: bundle:deps/require.lua: cannot load incompatible bytecode
```