### PR TITLE
Include lookup of mysql client library rev 21

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+## rackspace-monitoring-agent-2.6.22
+
+* Upgrade to latest luvi version to pick up 2.9.3 and openssl upgrade
+* Support MySQL client library rev 21
+
 ## rackspace-monitoring-agent-2.6.21
 
 * Fixed handling of -l command-line argument

--- a/check/base.lua
+++ b/check/base.lua
@@ -451,7 +451,7 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
   end)
 
   child.stderr:on('data', function(chunk)
-    self._log(logging.INFO, fmt("%s: stderr: ", exePath, chunk))
+    self._log(logging.INFO, fmt("%s: stderr: %s", exePath, chunk))
   end)
 
   local function waitForIO(callback)

--- a/check/mysql.lua
+++ b/check/mysql.lua
@@ -380,7 +380,8 @@ function MySQLCheck:_runCheckInChild(callback)
     '', -- default to no os extension
     '.16',
     '.17',
-    '.18'
+    '.18',
+    '.21'
   }
 
   local clib = self:_findLibrary(mysqlexact, mysqlpaths, osexts)

--- a/package.lua
+++ b/package.lua
@@ -1,8 +1,8 @@
 return {
   name = "rackspace-monitoring-agent",
-  version = "2.6.21",
+  version = "2.6.22-beta1",
   luvi = {
-    version = "2.7.6-2-sigar",
+    version = "2.9.3-1-sigar",
     flavor = "sigar",
     url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
   },


### PR DESCRIPTION
## Resolves

https://jira.rax.io/browse/CMC-2271

## What

- Include rev 21 for the mysql client library lookup
- Fix an issue where the stderr logging of sub-process checks (such as mysql) was not including the actual chunk
- Bump the luvi version to include latest openssl which resolves compatibility with MySQL 8 client library

## TODO

After a test build I'll set the version to a non-beta `2.6.22`
