### PR TITLE
Build lit as part of regular Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 build
 lit
+lit.exe
 luvi
+luvi.exe
 luvit
 luvi-sigar
+luvi-sigar.exe
 rackspace-monitoring-agent
 tests/tmpdir
 deps

--- a/Make.bat
+++ b/Make.bat
@@ -39,6 +39,8 @@ git clone --recursive https://github.com/luvit/lit.git
 if %errorlevel% neq 0 goto error
 cd lit
 git checkout %LIT_VERSION%
+@rem The following runs the lit source via luvi-sigar and calls itself to make the lit source
+@rem into ..\..\lit.exe and embedding specifically ..\..\luvi-sigar.exe as its luvi
 ..\..\luvi-sigar.exe . -- make . ..\..\lit.exe ..\..\luvi-sigar.exe
 if %errorlevel% neq 0 goto error
 cd ..\..

--- a/package.lua
+++ b/package.lua
@@ -2,7 +2,7 @@ return {
   name = "rackspace-monitoring-agent",
   version = "2.6.22",
   luvi = {
-    version = "2.7.6-2-sigar",
+    version = "2.9.3-sigar",
     flavor = "sigar",
     url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
   },


### PR DESCRIPTION
# Fixes

https://jira.rax.io/browse/CMC-2273

# What

Even with the luvi set to 2.9.3-sigar in `package.lua` the built agent exe was producing an error like https://github.com/luvit/lit/issues/252 .

What ended up fixing this (in local build testing at least) was doing two things:
1. Build lit from source, such as what the Linux builder script does here: https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent-buildbot-builder/blob/master/build.sh#L38-L44 
2. Instead of putting the lit-building logic way over in that repo, just incorporate it into this repo's `make.bat` since it was already doing "get lit" stuff