### PR TITLE
Removed explicit DEB dependency on xenstore-utils package

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## rackspace-monitoring-agent-2.6.23
+
+* For Debian packages, remove explicit dependency on xenstore-utils
+
 ## rackspace-monitoring-agent-2.6.22
 
 * Upgrade to luvi v2.9.3-sigar which includes openssl 1.1.1 upgrade

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,6 @@ if (${SPECIFIC_SYSTEM_VERSION_NAME} MATCHES "^Linux")
 
     include(CreateRepo)
   elseif(${SPECIFIC_SYSTEM_PREFERED_CPACK_GENERATOR} MATCHES "DEB")
-    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "xenstore-utils (>= 4.4.2-0)")
     ### Control Files
     set(DEB_POSTRM ${GENERATED_PACKAGE_SCRIPTS}/debian/postrm)
     configure_file(${PACKAGE_SCRIPTS}/debian/postrm.in ${DEB_POSTRM})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ if (${SPECIFIC_SYSTEM_VERSION_NAME} MATCHES "^Linux")
 
     include(CreateRepo)
   elseif(${SPECIFIC_SYSTEM_PREFERED_CPACK_GENERATOR} MATCHES "DEB")
+    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "xenstore-utils (>= 4.4.2-0) | xe-guest-utilities")
     ### Control Files
     set(DEB_POSTRM ${GENERATED_PACKAGE_SCRIPTS}/debian/postrm)
     configure_file(${PACKAGE_SCRIPTS}/debian/postrm.in ${DEB_POSTRM})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,6 @@ if (${SPECIFIC_SYSTEM_VERSION_NAME} MATCHES "^Linux")
 
     include(CreateRepo)
   elseif(${SPECIFIC_SYSTEM_PREFERED_CPACK_GENERATOR} MATCHES "DEB")
-    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "xenstore-utils (>= 4.4.2-0) | xe-guest-utilities")
     ### Control Files
     set(DEB_POSTRM ${GENERATED_PACKAGE_SCRIPTS}/debian/postrm)
     configure_file(${PACKAGE_SCRIPTS}/debian/postrm.in ${DEB_POSTRM})

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
-LIT_VERSION=3.7.3
+LIT_VERSION=3.8.1
 TARGET=build/rackspace-monitoring-agent
 LUVI?=./luvi
 LIT?=./lit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
-LIT_VERSION=3.8.1
+LIT_VERSION=3.7.3
 TARGET=build/rackspace-monitoring-agent
 LUVI?=./luvi
 LIT?=./lit

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "rackspace-monitoring-agent",
-  version = "2.6.22",
+  version = "2.6.23",
   luvi = {
     version = "2.9.3-sigar",
     flavor = "sigar",


### PR DESCRIPTION
For https://jira.rax.io/browse/CMC-2295 we need to remove the explicit dependency on the xenstore-utils package so that the VM setup has the option to provide `xenstore-read` from newer packages, such as `xe-guest-utilities`.