### PR TITLE
Upgraded lit to 3.8.1 to avoid incompatible bytecode issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
-LIT_VERSION=3.7.3
+LIT_VERSION=3.8.1
 TARGET=build/rackspace-monitoring-agent
 LUVI?=./luvi
 LIT?=./lit


### PR DESCRIPTION
The infamous build-mismatch and startup issue:
```
/luvi/src/lua/luvibundle.lua:321: bundle:deps/require.lua: cannot load incompatible bytecode
```

finally got fixed in lit 3.8.0...and 3.8.1 is now the latest:

https://github.com/luvit/lit/commit/ecab48cea61599710c9b0e6edccc85dddcbd2b35