### PR TITLE
updated LUVi and LIT version for windows check issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## rackspace-monitoring-agent-2.6.24
+
+* Fixed issues for windows check by updating the version back to old ones for LUVI and LIT.
+
 ## rackspace-monitoring-agent-2.6.23
 
 * For Debian packages, remove explicit dependency on xenstore-utils

--- a/Make.bat
+++ b/Make.bat
@@ -1,6 +1,6 @@
 REM @ECHO off
-@SET LIT_VERSION=3.7.3
-@SET LUVI_VERSION=v2.9.3-sigar
+@SET LIT_VERSION=3.1.0
+@SET LUVI_VERSION=v2.7.6-2-sigar
 
 IF NOT "x%1" == "x" GOTO :%1
 

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "rackspace-monitoring-agent",
-  version = "2.6.23",
+  version = "2.6.24",
   luvi = {
     version = "2.9.4-sigar",
     flavor = "sigar",


### PR DESCRIPTION
We got a query from customer that windows perf_os check are not working. We identified later that it is with all windows checks and it is because of some LIT version update and also related with windows TLS. So we rolled back to a latest version combination on which these checks are working fine.