### PR TITLE
Rolled back version to 2.6.23

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,7 @@
-## rackspace-monitoring-agent-2.6.24
-
-* Fixed issues for windows check by updating the version back to old ones for LUVI and LIT.
-
 ## rackspace-monitoring-agent-2.6.23
 
 * For Debian packages, remove explicit dependency on xenstore-utils
+* Fixed issues for windows check by updating the version back to old ones for LUVI and LIT.
 
 ## rackspace-monitoring-agent-2.6.22
 

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "rackspace-monitoring-agent",
-  version = "2.6.24",
+  version = "2.6.23",
   luvi = {
     version = "2.9.4-sigar",
     flavor = "sigar",


### PR DESCRIPTION
Moving back to 2.6.23 because we realized we can't push out only the Windows binaries. All the install files have to be here, so we copied the 2.6.24 Windows installers back to the 2.6.23 cloudfiles bucket and will push that out.
Another PR on same note -> https://github.com/rax-maas/ele-agent-repo-distribution/pull/38