### PR TITLE
Fix for plugin timeout test

### DIFF
--- a/check/base.lua
+++ b/check/base.lua
@@ -427,7 +427,7 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
 
   self._log(logging.DEBUG, fmt("%s: starting process", exePath))
 
-  local child = childprocess.spawn(exePath, exeArgs, { env = environ, detached = true})
+  local child = childprocess.spawn(exePath, exeArgs, { env = environ})
   child.stdin:destroy() -- close stdin for windows and ruby compatibility
 
   local pluginTimeout = timer.setTimeout(self._timeout, function()

--- a/check/base.lua
+++ b/check/base.lua
@@ -427,14 +427,14 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
 
   self._log(logging.DEBUG, fmt("%s: starting process", exePath))
 
-  local child = childprocess.spawn(exePath, exeArgs, { env = environ })
+  local child = childprocess.spawn(exePath, exeArgs, { env = environ, detached = true})
   child.stdin:destroy() -- close stdin for windows and ruby compatibility
 
   local pluginTimeout = timer.setTimeout(self._timeout, function()
     local timeoutSeconds = (self._timeout / 1000)
 
     self._log(logging.DEBUG, fmt("%s: Plugin didn't finish in %s seconds, killing it...", exePath, timeoutSeconds))
-    child:kill('sigkill')
+    uv.kill("-" .. child.pid, 9)
     killed = true
 
     checkResult:setError(fmt("Plugin didn't finish in %s seconds", timeoutSeconds))

--- a/check/base.lua
+++ b/check/base.lua
@@ -434,7 +434,7 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
     local timeoutSeconds = (self._timeout / 1000)
 
     self._log(logging.DEBUG, fmt("%s: Plugin didn't finish in %s seconds, killing it...", exePath, timeoutSeconds))
-    uv.kill("-" .. child.pid, 9)
+    uv.kill( child.pid, 9)
     killed = true
 
     checkResult:setError(fmt("Plugin didn't finish in %s seconds", timeoutSeconds))

--- a/package.lua
+++ b/package.lua
@@ -2,7 +2,7 @@ return {
   name = "rackspace-monitoring-agent",
   version = "2.6.23",
   luvi = {
-    version = "2.9.4-sigar",
+    version = "2.7.6-2-sigar",
     flavor = "sigar",
     url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
   },

--- a/package.lua
+++ b/package.lua
@@ -2,7 +2,7 @@ return {
   name = "rackspace-monitoring-agent",
   version = "2.6.23",
   luvi = {
-    version = "2.7.6-2-sigar",
+    version = "2.9.4-sigar",
     flavor = "sigar",
     url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
   },

--- a/static/tests/custom_plugins/timeout.sh
+++ b/static/tests/custom_plugins/timeout.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-sleep 500
+sleep 500&
+PID=$!
+trap "kill $PID" EXIT


### PR DESCRIPTION
Since the child:kill('sigkill') is unable to kill the child process (the sleep within the timeout.sh), I used [uv_kill](https://github.com/libuv/libuv/blob/v1.x/src/win/process.c#L1259) to achieve the result.

Also, here we need to prefix a minus (-) sign in front of the processID, since that will [kill all the processes](https://morningcoffee.io/killing-a-process-and-all-of-its-descendants.html) under this process group (i.e, killing all attached processes/ children) 
