### PR TITLE
Adding notes for plugin timeout

### DIFF
--- a/check/base.lua
+++ b/check/base.lua
@@ -434,6 +434,13 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
     local timeoutSeconds = (self._timeout / 1000)
 
     self._log(logging.DEBUG, fmt("%s: Plugin didn't finish in %s seconds, killing it...", exePath, timeoutSeconds))
+    --[[ After trying various approaches w.r.t killing a child process within the specified timeout with libuv, none of them seem to work if the childProcess is not detached,
+    since the sleep within 'plugin timeout test' creates a child within a spawned childprocess.
+    A detached process which is created by passing the relevant flag in the options {} to the spawn() command, has its own PGID (process group ID).
+    This makes it easy to kill the entire process group (including its children processes) by prefixing a - (minus sign) to the PGID, example: uv.kill(-child.pid, 'sigkill')
+    We will have to test extensively in staging if we run every plugin with a child process as detached, as the repercussions in production may be unprecedented.
+    ]]
+
     child:kill('sigkill')
     killed = true
 

--- a/static/tests/custom_plugins/timeout.sh
+++ b/static/tests/custom_plugins/timeout.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-sleep 500
+sleep 5
+#reducing the timeout since it stalls the progress of other tests for 500 seconds


### PR DESCRIPTION
All relevant findings regarding the killing of spawned children and limitations of the libuv framework to do so were added to the code, and timeout.sh timeout was reduced to 5 seconds so that other tests are not stalled for so long.