### PR TITLE
Using an env variable as a flag to spawn detached child checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,13 @@ cd /agent2/src/rackspace-monitoring-agent
 ./luvi-sigar . -m tests/run.lua 
 ```
 
+Environment Variables
+=====================
+
+<h3>SPAWN_CHECKS_DETACHED </h3>
+
+This env variable SPAWN_CHECKS_DETACHED can be passed with its value while running tests as below:
+```
+SPAWN_CHECKS_DETACHED=true make test
+```
+This gets stored in **_process.env_** table. The relevant code in [base.lua](https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/blob/master/check/base.lua) fetches this value, hence spawning child processes within checks as detached.

--- a/check/base.lua
+++ b/check/base.lua
@@ -437,6 +437,13 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
 
     self._log(logging.DEBUG, fmt("%s: Plugin didn't finish in %s seconds, killing it...", exePath, timeoutSeconds))
 
+    --[[ After trying various approaches w.r.t killing a child process within the specified timeout with libuv, none of them seem to work if the childProcess is not detached,
+    since the sleep within 'plugin timeout test' creates a child within a spawned childprocess.
+    A detached process which is created by passing the relevant flag in the options {} to the spawn() command, has its own PGID (process group ID).
+    This makes it easy to kill the entire process group (including its children processes) by prefixing a - (minus sign) to the PGID.
+    We will have to test extensively in staging if we run every plugin with a child process as detached, as the repercussions in production may be unprecedented.
+    ]]
+
     uv.kill("-" .. child.pid, 9)     -- We use this command to kill a detached process group, the minus (-) prefix indicates that we kill the entire process group
     killed = true
 

--- a/check/base.lua
+++ b/check/base.lua
@@ -425,23 +425,19 @@ function ChildCheck:_runChild(exePath, exeArgs, environ, callback)
 
   callback = fireOnce(callback)
 
+  local detach_const = process.env['SPAWN_CHECKS_DETACHED'] or false
   self._log(logging.DEBUG, fmt("%s: starting process", exePath))
 
-  local child = childprocess.spawn(exePath, exeArgs, { env = environ })
+  local child = childprocess.spawn(exePath, exeArgs, { env = environ,
+                                                       detached = detach_const})
   child.stdin:destroy() -- close stdin for windows and ruby compatibility
 
   local pluginTimeout = timer.setTimeout(self._timeout, function()
     local timeoutSeconds = (self._timeout / 1000)
 
     self._log(logging.DEBUG, fmt("%s: Plugin didn't finish in %s seconds, killing it...", exePath, timeoutSeconds))
-    --[[ After trying various approaches w.r.t killing a child process within the specified timeout with libuv, none of them seem to work if the childProcess is not detached,
-    since the sleep within 'plugin timeout test' creates a child within a spawned childprocess.
-    A detached process which is created by passing the relevant flag in the options {} to the spawn() command, has its own PGID (process group ID).
-    This makes it easy to kill the entire process group (including its children processes) by prefixing a - (minus sign) to the PGID, example: uv.kill(-child.pid, 'sigkill')
-    We will have to test extensively in staging if we run every plugin with a child process as detached, as the repercussions in production may be unprecedented.
-    ]]
 
-    child:kill('sigkill')
+    uv.kill("-" .. child.pid, 9)     -- We use this command to kill a detached process group, the minus (-) prefix indicates that we kill the entire process group
     killed = true
 
     checkResult:setError(fmt("Plugin didn't finish in %s seconds", timeoutSeconds))


### PR DESCRIPTION
If we pass SPAWN_CHECKS_DETACHED as true while running tests, we will be able to spawn child checks as detached processes, which can then be killed within the specified timeout. This will help in testing whether spawning detached child processes in staging will have any repercussions