### PR TITLE
Fix Luvi Sigar version

### DIFF
--- a/package.lua
+++ b/package.lua
@@ -2,7 +2,7 @@ return {
   name = "rackspace-monitoring-agent",
   version = "2.6.23",
   luvi = {
-    version = "2.9.4-sigar",
+    version = "2.7.6-2-sigar",
     flavor = "sigar",
     url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
   },


### PR DESCRIPTION
The luvi sigar version 2.9.4 doesn't exist, 2.7.6-2 is the correct version for Darwin