### PR TITLE
Fix gpg: cannot open '/dev/tty': No such device or address error.

### DIFF
--- a/cmake/CreateRepo.cmake
+++ b/cmake/CreateRepo.cmake
@@ -12,7 +12,7 @@ add_custom_target(packagerepo
   COMMAND cp -f ${CMAKE_CURRENT_SOURCE_DIR}/cmake/package/rpm/rpm_macros_gpg ~/.rpmmacros
   COMMAND rpm --addsign ${REPO_PATH}/*.rpm
   COMMAND createrepo ${REPO_PATH}
-  COMMAND gpg --detach-sign --armor ${REPO_PATH}/repodata/repomd.xml
+  COMMAND gpg --batch --detach-sign --armor ${REPO_PATH}/repodata/repomd.xml
 )
 add_custom_target(packagerepoupload
   COMMAND rclone mkdir ${REPO_UPLOAD_CLOUD}:${VERSION_SHORT}/${REPO_NAME}


### PR DESCRIPTION
When we were doing the agent build, we got above error which was refering that job was not able to get the terminal. This is because we ran the job from buildbot UI not server terminal. To overcome from this issue, the solution was to run the job in batch mode which will not ask for input like Y/N and hence solve the issue.