### PR TITLE
ubunutu-24 agent build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts
+build/
+dist/
+*.deb
+*.rpm
+*.msi
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation
+*.md
+
+# CI/CD
+.travis.yml
+appveyor.yml
+.github/
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Vagrant
+.vagrant/
+Vagrantfile
+
+# Tests
+tests/tmpdir/
+
+# Misc
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@ GPATH
 GRTAGS
 GTAGS
 /.idea
+
+# Private keys - never commit
+server.key
+*.pem
+agent-package-signing-key.txt
+dist
+signing-key.asc
+.DS_Store
+vendor-sigar
+.docker-context
+src/
+buildtools/

--- a/BUILD-UBUNTU24.md
+++ b/BUILD-UBUNTU24.md
@@ -1,0 +1,144 @@
+# Building rackspace-monitoring-agent for Ubuntu 24.04
+
+Build Debian packages for rackspace-monitoring-agent compatible with Ubuntu 24.04 using Docker.
+
+## Prerequisites
+
+- Docker installed and running
+- ~2GB free disk space
+- Internet connection
+
+## Sigar Dependency
+
+The build requires the [racker/sigar](https://github.com/racker/sigar) project (private repo) to be available as a sibling directory to this project:
+
+```
+parent-directory/
+├── rackspace-monitoring-agent/   # this project
+└── sigar/                        # required sibling
+```
+
+Clone it manually (requires SSH access to the private repo):
+
+```bash
+cd ..
+git clone git@github.com:racker/sigar.git
+cd rackspace-monitoring-agent
+```
+
+The build script will error out with instructions if sigar is not found.
+
+## Signing Keys
+
+The build produces signed packages and a signed APT repository. The following files must be placed in the project root before building:
+
+| File | Purpose |
+|------|---------|
+| `server.key` | Signs the agent binary (generates `.sig` file) |
+| `signing-key.asc` | Public key included in meta packages for APT verification |
+| `agent-package-signing-key.txt` | GPG private key used to sign the APT repository (`InRelease`, `Release.gpg`) |
+
+These files can be found at: https://passwordsafe.corp.rackspace.com/projects/42902
+
+> **Note:** The build will still succeed without these files, but the binary will not be signed, and the signed APT repository and meta packages will not be generated.
+
+## Build the Package
+
+> **Note:** The first build takes 15-20 minutes as it downloads all dependencies and compiles from source. Subsequent builds are much faster due to Docker layer caching.
+
+Since sigar is a private repository, you must clone it manually before building:
+
+```bash
+cd ..
+git clone git@github.com:racker/sigar.git   # requires SSH access
+cd rackspace-monitoring-agent
+```
+
+The Docker build context must be the **parent directory** containing both projects:
+
+```bash
+mkdir -p dist
+docker build -f rackspace-monitoring-agent/Dockerfile.ubuntu24 -t rma-ubuntu24-builder ..
+docker run --rm -v "$(pwd)/dist:/output" rma-ubuntu24-builder
+```
+
+Or use the Makefile target (if updated):
+
+```bash
+make ubuntu24-build
+```
+
+## Test Installation (Docker)
+
+Quick test in a clean Ubuntu 24.04 container:
+
+```bash
+make ubuntu24-test
+```
+
+## Test Installation (Vagrant)
+
+For a full VM test with systemd, networking, etc:
+
+```bash
+# Build the .deb first, then:
+vagrant up        # boots VM, copies .deb, installs it
+vagrant ssh       # SSH in to inspect
+
+# Inside the VM:
+rackspace-monitoring-agent -v
+sudo systemctl status rackspace-monitoring-agent
+sudo journalctl -u rackspace-monitoring-agent -f
+```
+
+To re-test after rebuilding the `.deb`:
+
+```bash
+vagrant destroy -f
+vagrant up
+```
+
+## Other Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `make ubuntu24-build` | Build the `.deb` package |
+| `make ubuntu24-test` | Test install in a clean container |
+| `make ubuntu24-shell` | Interactive shell in build environment |
+| `make ubuntu24-clean` | Remove build image and dist artifacts |
+
+## Build Process
+
+1. Uses Ubuntu 24.04 Docker image as build environment
+2. Installs build tools (cmake, gcc, dpkg-dev, debhelper, etc.)
+3. Downloads luvi-sigar runtime and builds lit package manager
+4. Compiles the agent binary via CMake
+5. Creates the Debian package via CPack
+6. Copies `.deb` to `./dist/`
+
+## Package Contents
+
+- `/usr/bin/rackspace-monitoring-agent`
+- `/etc/systemd/system/rackspace-monitoring-agent.service`
+- `/etc/init.d/rackspace-monitoring-agent` (SysV)
+- `/etc/init/rackspace-monitoring-agent.conf` (Upstart)
+- `/etc/rackspace-monitoring-agent.conf.d/`
+- `/var/lib/rackspace-monitoring-agent/`
+- `/usr/lib/rackspace-monitoring-agent/plugins/`
+- `/etc/logrotate.d/rackspace-monitoring-agent`
+
+## Deploy to a VM
+
+```bash
+scp dist/rackspace-monitoring-agent-*.deb user@your-vm:/tmp/
+ssh user@your-vm
+sudo apt-get install -y /tmp/rackspace-monitoring-agent-*.deb
+rackspace-monitoring-agent -v
+```
+
+## Troubleshooting
+
+- Docker not running? `docker ps`
+- Permission issues? `sudo chown -R $USER:$USER dist/`
+- Need to debug the build? `make ubuntu24-shell`
+- Out of disk? `docker system prune -a`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ if (${SPECIFIC_SYSTEM_VERSION_NAME} MATCHES "^Linux")
 
     include(CreateRepo)
   elseif(${SPECIFIC_SYSTEM_PREFERED_CPACK_GENERATOR} MATCHES "DEB")
+    ### Package Dependencies
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libtirpc3")
+
     ### Control Files
     set(DEB_POSTRM ${GENERATED_PACKAGE_SCRIPTS}/debian/postrm)
     configure_file(${PACKAGE_SCRIPTS}/debian/postrm.in ${DEB_POSTRM})

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -1,0 +1,39 @@
+FROM ubuntu:24.04
+
+LABEL maintainer="Rackspace Monitoring"
+LABEL description="Build rackspace-monitoring-agent on Ubuntu 24.04 with repo-ready artifacts"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential cmake git curl ca-certificates \
+    dpkg-dev debhelper fakeroot lsb-release file \
+    reprepro gnupg openssl rclone \
+    libtirpc-dev perl luajit libluajit-5.1-dev libuv1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04 moved rpc headers to tirpc — sigar expects them at standard path
+RUN ln -s /usr/include/tirpc/rpc /usr/include/rpc && \
+    ln -s /usr/include/tirpc/netconfig.h /usr/include/netconfig.h
+
+WORKDIR /build
+
+# Copy the agent project and sigar (sigar must be pre-cloned as a sibling directory)
+# The Makefile prepares a temporary build context with the expected directory names.
+COPY agent/ /build/rackspace-monitoring-agent/
+COPY sigar/ /build/sigar/
+
+WORKDIR /build/rackspace-monitoring-agent
+RUN chmod +x build-ubuntu24.sh && ./build-ubuntu24.sh
+
+# Copy all repo-ready artifacts to /output
+CMD ["bash", "-c", "\
+  mkdir -p /output && \
+  cd /build/rackspace-monitoring-agent && \
+  cp -f build/ubuntu-24.04-*-rackspace-monitoring-agent-* /output/ 2>/dev/null; \
+  cp -rf build/ubuntu-24.04-* /output/ 2>/dev/null; \
+  cp -f build/*.deb /output/ 2>/dev/null; \
+  cp -f build/VERSION /output/ 2>/dev/null; \
+  cp -f meta/*.deb /output/ 2>/dev/null; \
+  echo '==> Artifacts:' && ls -lhR /output/"]

--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,35 @@ siggen:
 siggenupload:
 	cmake --build build -- siggenupload
 
-.PHONY: clean lint package packagerepo packagerepoupload siggen siggenupload install
+# Ubuntu 24.04 Docker build targets
+ubuntu24-build:
+	@echo "==> Building rackspace-monitoring-agent .deb for Ubuntu 24.04"
+	@echo "==> First build may take 15-20 minutes (downloading dependencies, compiling)."
+	@echo "==> Subsequent builds will be faster due to Docker layer caching."
+	@if [ ! -d "../sigar" ]; then \
+		echo "ERROR: ../sigar directory not found."; \
+		echo "Clone the private sigar repo as a sibling directory first:"; \
+		echo "  git clone git@github.com:racker/sigar.git ../sigar"; \
+		exit 1; \
+	fi
+	mkdir -p dist
+	rm -rf .docker-context && mkdir -p .docker-context
+	cp -a . .docker-context/agent
+	cp -a ../sigar .docker-context/sigar
+	docker build -f .docker-context/agent/Dockerfile.ubuntu24 -t rma-ubuntu24-builder .docker-context
+	rm -rf .docker-context
+	docker run --rm -v "$$(pwd)/dist:/output" rma-ubuntu24-builder
+	@echo "==> Done. Package is in ./dist/"
+
+ubuntu24-test:
+	docker run --rm -v "$$(pwd)/dist:/packages:ro" ubuntu:24.04 \
+		bash -c "apt-get update && apt-get install -y /packages/*.deb && rackspace-monitoring-agent -v"
+
+ubuntu24-shell:
+	docker run --rm -it -v "$$(pwd)/dist:/output" rma-ubuntu24-builder bash
+
+ubuntu24-clean:
+	rm -rf dist/
+	-docker rmi rma-ubuntu24-builder 2>/dev/null
+
+.PHONY: clean lint package packagerepo packagerepoupload siggen siggenupload install ubuntu24-build ubuntu24-test ubuntu24-clean ubuntu24-shell

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+    vb.cpus = 2
+  end
+
+  config.vm.provision "file",
+    source: "./dist/rackspace-monitoring-agent-2.6.23-amd64.deb",
+    destination: "/tmp/rackspace-monitoring-agent-2.6.23-amd64.deb"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update -qq
+    apt-get install -y /tmp/rackspace-monitoring-agent-2.6.23-amd64.deb
+    echo "=== Checking installed version ==="
+    rackspace-monitoring-agent -v
+  SHELL
+end

--- a/build-meta-debs.sh
+++ b/build-meta-debs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Build meta packages (stable, master, unstable) for ubuntu-24.04-x86_64.
+# These configure apt sources on target machines to point at the correct repo channel.
+# Usage: ./build-meta-debs.sh <gpg_key_file> <output_dir>
+set -e
+
+GPG_KEY_FILE="${1:-signing-key.asc}"
+OUTPUT_DIR="${2:-/build/meta}"
+PLATFORM="ubuntu-24.04-x86_64"
+
+GPG_KEY=""
+if [ -f "$GPG_KEY_FILE" ]; then
+  GPG_KEY=$(cat "$GPG_KEY_FILE")
+else
+  echo "WARNING: $GPG_KEY_FILE not found, meta debs will have empty GPG key"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+for CHANNEL in stable master unstable; do
+  PKG="rackspace-cloud-monitoring-meta-${CHANNEL}"
+  DIR="${OUTPUT_DIR}/${PKG}"
+  CHANNEL_UPPER="$(echo "$CHANNEL" | sed 's/./\U&/')"
+
+  rm -rf "$DIR"
+  mkdir -p "${DIR}/DEBIAN" "${DIR}/usr/share/doc/${PKG}"
+
+  # control
+  cat > "${DIR}/DEBIAN/control" <<EOF
+Package: ${PKG}
+Version: 1.0
+Architecture: all
+Maintainer: Rackspace Cloud Monitoring <monitoring@rackspace.com>
+Installed-Size: 14
+Section: unknown
+Priority: extra
+Description: Rackspace Cloud Monitoring ${CHANNEL_UPPER} Repo
+EOF
+
+  # postinst — Ubuntu 24.04 uses signed-by keyrings instead of apt-key
+  KEYRING_PATH="/etc/apt/keyrings/rackspace-monitoring.gpg"
+
+  cat > "${DIR}/DEBIAN/postinst" <<POSTINST_HEADER
+#!/bin/sh
+#
+KEYRING="${KEYRING_PATH}"
+REPOCONFIG="deb [signed-by=${KEYRING_PATH}] https://${CHANNEL}.packages.cloudmonitoring.rackspace.com/${PLATFORM} cloudmonitoring main"
+POSTINST_HEADER
+
+  cat >> "${DIR}/DEBIAN/postinst" <<'POSTINST_BODY'
+
+SOURCES_PREAMBLE="### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+# You may comment out this entry, but any other modifications may be lost.\n"
+
+install_key() {
+  mkdir -p /etc/apt/keyrings
+  cat > /tmp/rackspace-monitoring-key.asc <<KEYDATA
+POSTINST_BODY
+
+  # Inject the actual GPG key
+  echo "$GPG_KEY" >> "${DIR}/DEBIAN/postinst"
+
+  cat >> "${DIR}/DEBIAN/postinst" <<'POSTINST_TAIL'
+KEYDATA
+  gpg --dearmor -o "$KEYRING" /tmp/rackspace-monitoring-key.asc 2>/dev/null
+  rm -f /tmp/rackspace-monitoring-key.asc
+  chmod 644 "$KEYRING"
+}
+
+create_sources_lists() {
+  if [ ! "$REPOCONFIG" ]; then
+    return 0
+  fi
+
+  SOURCESDIR="/etc/apt/sources.list.d"
+  SOURCELIST="${SOURCESDIR}/rackspace-monitoring.list"
+
+  if [ -d "$SOURCESDIR" ]; then
+    printf "$SOURCES_PREAMBLE" > "$SOURCELIST"
+    printf "$REPOCONFIG\n" >> "$SOURCELIST"
+  fi
+}
+
+## MAIN ##
+install_key
+create_sources_lists
+POSTINST_TAIL
+
+  chmod 755 "${DIR}/DEBIAN/postinst"
+  echo "${PKG} for Ubuntu 24.04" > "${DIR}/usr/share/doc/${PKG}/README.Debian"
+
+  if [ -f /build/LICENSE.txt ]; then
+    cp /build/LICENSE.txt "${DIR}/usr/share/doc/${PKG}/copyright"
+  else
+    echo "Copyright Rackspace" > "${DIR}/usr/share/doc/${PKG}/copyright"
+  fi
+
+  (cd "${DIR}" && find usr -type f -exec md5sum {} \;) > "${DIR}/DEBIAN/md5sums"
+
+  dpkg-deb --build "${DIR}" "${OUTPUT_DIR}/${PKG}_1.0_all.deb"
+  echo "Built: ${PKG}_1.0_all.deb"
+done
+
+echo "==> Meta packages built in ${OUTPUT_DIR}"

--- a/build-ubuntu24.sh
+++ b/build-ubuntu24.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Build script for rackspace-monitoring-agent on Ubuntu 24.04.
+# Based on: https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent-buildbot-builder/blob/master/build.sh
+# With fixes for Ubuntu 24.04 compatibility:
+#   - racker/sigar expected as a sibling directory (../sigar relative to this project)
+#   - libtirpc headers symlinked for rpc/rpc.h
+#   - LuaJIT updated to commit c3459468 (Aug 2023, works on modern kernels)
+#   - Uses system shared OpenSSL instead of building from source
+set -eu
+
+LUVI_VERSION=2.9.4-sigar
+LIT_VERSION=3.7.3
+LIT_URL="https://lit.luvit.io/packages/luvit/lit/v$LIT_VERSION.zip"
+LUVI_URL="https://github.com/virgo-agent-toolkit/luvi.git"
+SIGAR_REPO="https://github.com/racker/sigar.git"
+
+# Resolve the directory containing this script (i.e., the agent project root)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Sigar is expected as a sibling directory to this project
+SIGAR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)/sigar"
+
+BUILD_DIR=${PWD}/buildtools
+SRC_DIR=${PWD}/src
+AGENT_DIR=${SCRIPT_DIR}
+
+export LIT=${BUILD_DIR}/lit
+export LUVI=${BUILD_DIR}/luvi
+export PATH=${BUILD_DIR}:$PATH
+
+# Ensure sigar is available
+ensure_sigar() {
+  if [ ! -d "${SIGAR_DIR}" ]; then
+    echo "ERROR: sigar directory not found at ${SIGAR_DIR}" >&2
+    echo "" >&2
+    echo "The sigar project is required as a sibling directory to this project." >&2
+    echo "Since it is a private repository, you must clone it manually:" >&2
+    echo "" >&2
+    echo "  git clone ${SIGAR_REPO} ${SIGAR_DIR}" >&2
+    echo "" >&2
+    echo "Expected layout:" >&2
+    echo "  parent-dir/" >&2
+    echo "  ├── rackspace-monitoring-agent/" >&2
+    echo "  └── sigar/" >&2
+    exit 1
+  fi
+  echo "==> Using sigar from ${SIGAR_DIR}"
+}
+
+setup() {
+  mkdir -p ${BUILD_DIR} ${SRC_DIR}
+}
+
+build_luvi() {
+  LUVI_DIR="${SRC_DIR}/luvi-${LUVI_VERSION}"
+  if [ ! -d ${LUVI_DIR} ]; then
+    # Clone without recursing — we need to fix broken submodule URLs
+    git clone --branch ${LUVI_VERSION} ${LUVI_URL} ${LUVI_DIR}
+    pushd ${LUVI_DIR}
+      # Init all submodules except lua-sigar (which references racker/sigar)
+      git submodule update --init --recursive -- deps/lpeg deps/lrexlib deps/lua-openssl deps/lua-zlib deps/luv deps/pcre deps/zlib
+
+      # Fix lua-sigar: use sibling sigar project instead of unavailable racker/sigar submodule
+      git submodule update --init -- deps/lua-sigar
+      # Manually place sigar source where the submodule expects it
+      rm -rf deps/lua-sigar/deps/sigar
+      cp -r "${SIGAR_DIR}" deps/lua-sigar/deps/sigar
+
+      # Replace bundled LuaJIT with a newer version that works on modern kernels.
+      # The bundled version segfaults on Ubuntu 24.04 (both x86_64 and ARM64).
+      # We use the system libluajit for linking (swapped in during the build step).
+    popd
+  fi
+
+  pushd ${LUVI_DIR}
+    # Build with static OpenSSL (bundled 1.x, since system OpenSSL 3.x is incompatible
+    # with this old lua-openssl code). -w suppresses GCC 13 warnings-as-errors.
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_FLAGS="-w" \
+      -DWithOpenSSL=ON -DWithSharedOpenSSL=OFF \
+      -DWithPCRE=ON -DWithSharedPCRE=OFF \
+      -DWithLPEG=ON -DWithSigar=ON
+    # Build all targets. This will fail at the luvi bytecode step (segfault) but
+    # all libraries and the luajit binary will be built.
+    cmake --build build 2>&1 || true
+    # The bundled LuaJIT segfaults on Ubuntu 24.04 when used for bytecode compilation.
+    # Replace the bundled luajit commands with system luajit in the build rules.
+    # Command lines: "deps/luv/luajit -bg ..." -> "/usr/bin/luajit -bg ..."
+    # Dependency lines: "target: deps/luv/luajit" -> remove the dependency
+    # We use sed with a tab prefix to target only command lines (indented with tab).
+    sed -i 's|\tdeps/luv/luajit |\t/usr/bin/luajit |g' build/CMakeFiles/luvi.dir/build.make
+    # Remove dependency lines that reference the bundled luajit binary
+    # These lines look like: "jitted_tmp/foo.o: deps/luv/luajit"
+    sed -i '/^[^ ]*: deps\/luv\/luajit$/d' build/CMakeFiles/luvi.dir/build.make
+    # Remove the bundled jit/ module directory so system luajit doesn't pick up
+    # the bundled bcsave.lua (which causes a version mismatch).
+    rm -rf build/jit
+    # Prevent cmake from regenerating build rules (which would undo our sed changes)
+    touch build/CMakeFiles/cmake.check_cache
+    # Patch command lines to set LUA_PATH before invoking system luajit, forcing it
+    # to use its own system modules instead of any local ./jit/ directory that cmake
+    # may recreate when building the luajit dependency target.
+    sed -i 's|\t/usr/bin/luajit |\tLUA_PATH="/usr/share/luajit-2.1/?.lua;;" /usr/bin/luajit |g' build/CMakeFiles/luvi.dir/build.make
+    # Rebuild only the luvi target (bytecode + link step) using system luajit for
+    # compilation but the original bundled libluajit.a for linking.
+    # Replace the bundled libluajit.a with the system one so the luvi runtime
+    # doesn't segfault on modern kernels.
+    SYSTEM_LIBLUAJIT=$(find /usr -name 'libluajit-5.1.a' 2>/dev/null | head -1)
+    if [ -n "${SYSTEM_LIBLUAJIT}" ]; then
+      BUNDLED_LIBLUAJIT=$(find build -name 'libluajit.a' -o -name 'libluajit-5.1.a' 2>/dev/null | head -1)
+      if [ -n "${BUNDLED_LIBLUAJIT}" ]; then
+        echo "==> Replacing bundled libluajit (${BUNDLED_LIBLUAJIT}) with system (${SYSTEM_LIBLUAJIT})"
+        cp "${SYSTEM_LIBLUAJIT}" "${BUNDLED_LIBLUAJIT}"
+      fi
+    fi
+    cmake --build build -- luvi
+    cp build/luvi ${BUILD_DIR}/luvi
+  popd
+}
+
+build_lit() {
+  if [ ! -f ${SRC_DIR}/lit.zip ]; then
+    curl -kL $LIT_URL > ${SRC_DIR}/lit.zip
+  fi
+  if [ ! -x ${BUILD_DIR}/lit ]; then
+    pushd ${BUILD_DIR}
+      ${BUILD_DIR}/luvi ${SRC_DIR}/lit.zip -- make ${SRC_DIR}/lit.zip ${BUILD_DIR}/lit ${BUILD_DIR}/luvi
+    popd
+  fi
+}
+
+build_agent() {
+  pushd ${AGENT_DIR}
+    # Symlink build tools into agent source tree
+    ln -f -s ${LUVI} luvi-sigar
+    ln -f -s ${LUVI} luvi
+    ln -f -s ${LIT} lit
+
+    # server.key for signing
+    if [ -f "server.key" ]; then
+      cp server.key ~/server.key
+    fi
+
+    # Build agent
+    make
+    make package
+
+    # Sign binary (skips if ~/server.key absent)
+    cd build && make siggen 2>&1 || true
+    cd ..
+
+    # Import GPG key and build signed repo
+    if [ -f "agent-package-signing-key.txt" ]; then
+      gpg --batch --import agent-package-signing-key.txt
+      echo "==> GPG key D05AB914 imported"
+      make packagerepo
+    else
+      echo "WARNING: agent-package-signing-key.txt not found, skipping packagerepo"
+    fi
+
+    # Build meta packages
+    if [ -f "build-meta-debs.sh" ]; then
+      chmod +x build-meta-debs.sh
+      ./build-meta-debs.sh signing-key.asc /build/meta
+    fi
+  popd
+}
+
+ensure_sigar
+setup
+build_luvi
+build_lit
+build_agent

--- a/cmake/repo/reprepro.in
+++ b/cmake/repo/reprepro.in
@@ -1,6 +1,6 @@
 Codename: cloudmonitoring
 Components: main
-Architectures: i386 amd64 source
+Architectures: i386 amd64 arm64 source
 Origin: Rackspace
 Description: Rackspace Cloud Monitoring Agent
 SignWith: D05AB914

--- a/package.lua
+++ b/package.lua
@@ -4,7 +4,7 @@ return {
   luvi = {
     version = "2.7.6-2-sigar",
     flavor = "sigar",
-    url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s-sigar/luvi-%s-%s"
+    url = "https://github.com/virgo-agent-toolkit/luvi/releases/download/v%s/luvi-%s-%s"
   },
   dependencies = {
     "rphillips/options@0.0.5",


### PR DESCRIPTION
monitoring agent builedbot environment is not being maintained. We had a priority request to build monitoring agent for ubuntu-24 flavor.
This PR creates necessary build, packaging implementation using Docker.

To build:
`make ubuntu24-build`

You also need to create files server.key, signing-key.asc, agent-package-signing-key.txt at project root.
https://passwordsafe.corp.rackspace.com/projects/42902 has contents for these files.

To test: Note the `2.6.23 (virgo 2.1.10, luvi 2.9.4-sigar, libuv 1.30.1, OpenSSL 1.1.1b  26 Feb 2019)` line in output. This comes from running `rackspace-monitoring-agent -v` command after installing debian package

```
make ubuntu24-test
docker run --rm -v "$(pwd)/dist:/packages:ro" ubuntu:24.04 \
		bash -c "apt-get update && apt-get install -y /packages/*.deb && rackspace-monitoring-agent -v"
Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]
.....
......

Setting up libtirpc3t64:arm64 (1.3.4+ds-1.1build1) ...
Setting up rackspace-monitoring-agent (2.6.23) ...
 * Stopping rackspace-monitoring-agent rackspace-monitoring-agent
   ...fail!
Processing triggers for libc-bin (2.39-0ubuntu8.7) ...
2.6.23 (virgo 2.1.10, luvi 2.9.4-sigar, libuv 1.30.1, OpenSSL 1.1.1b  26 Feb 2019)

```

Refer to BUILD-UBUNTU24.md for additional details.